### PR TITLE
docs: rename app to SmartRedirect Suite

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,4 +1,4 @@
-# URL Migration Tool - Enterprise API Documentation
+# SmartRedirect Suite - Enterprise API Documentation
 
 > **Übersicht**: Diese API-Dokumentation beschreibt alle verfügbaren REST-Endpunkte für die URL-Migration-Anwendung. Für Installation siehe [INSTALLATION.md](./INSTALLATION.md), für vollständige Feature-Informationen [README.md](./README.md).
 
@@ -9,7 +9,7 @@
 
 ## Overview
 
-The URL Migration Tool provides a comprehensive REST API for managing URL transformation rules, tracking migration statistics, and administering the system. This documentation covers all available endpoints with enterprise-grade features including authentication, validation, performance monitoring, and bulk operations.
+The SmartRedirect Suite provides a comprehensive REST API for managing URL transformation rules, tracking migration statistics, and administering the system. This documentation covers all available endpoints with enterprise-grade features including authentication, validation, performance monitoring, and bulk operations.
 
 ## Base URL
 ```
@@ -133,7 +133,7 @@ GET /api/admin/settings
 ```json
 {
   "id": "settings_uuid",
-  "headerTitle": "URL Migration Tool",
+  "headerTitle": "SmartRedirect Suite",
   "headerIcon": "ArrowRightLeft",
   "headerLogoUrl": "/objects/uploads/logo.png",
   "mainTitle": "Outdated Link Detected",
@@ -717,4 +717,4 @@ npm install -g artillery
 artillery quick --count 100 --num 10 http://localhost:5000/api/health
 ```
 
-This comprehensive API documentation provides all the information needed to integrate with and maintain the URL Migration Tool in enterprise environments.
+This comprehensive API documentation provides all the information needed to integrate with and maintain the SmartRedirect Suite in enterprise environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ### 🎉 Erste vollständige Version
 
-Diese Version stellt die erste produktionsreife Version der URL-Migration-Anwendung dar. Alle Kernfunktionen sind implementiert und getestet.
+Diese Version stellt die erste produktionsreife Version der SmartRedirect Suite dar. Alle Kernfunktionen sind implementiert und getestet.
 
 ### ✨ Hauptfunktionen
 

--- a/ENTERPRISE_DEPLOYMENT.md
+++ b/ENTERPRISE_DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# Enterprise URL Migration Tool - Production Deployment Guide
+# SmartRedirect Suite - Enterprise Production Deployment Guide
 
 > **Zielgruppe**: DevOps-Engineers, System-Administratoren und Enterprise-Entwickler. Für Standard-Installation siehe [INSTALLATION.md](./INSTALLATION.md). Für API-Integration konsultieren Sie [API_DOCUMENTATION.md](./API_DOCUMENTATION.md).
 
@@ -10,7 +10,7 @@
 
 ## Overview
 
-This document provides comprehensive deployment instructions for the enterprise-grade URL migration tool, designed for large-scale production environments with high availability, security, and performance requirements including bulk operations and mobile-responsive interfaces.
+This document provides comprehensive deployment instructions for the enterprise-grade SmartRedirect Suite, designed for large-scale production environments with high availability, security, and performance requirements including bulk operations and mobile-responsive interfaces.
 
 ## Architecture Summary
 
@@ -142,7 +142,7 @@ npm install -g pm2
 cat > ecosystem.config.js << 'EOF'
 module.exports = {
   apps: [{
-    name: 'url-migration-tool',
+    name: 'smartredirect-suite',
     script: 'dist/index.js',
     instances: 'max',
     exec_mode: 'cluster',
@@ -196,7 +196,7 @@ echo "*.* @@logserver:514" >> /etc/rsyslog.conf
 systemctl restart rsyslog
 
 # Log rotation
-cat > /etc/logrotate.d/url-migration << 'EOF'
+cat > /etc/logrotate.d/smartredirect << 'EOF'
 /path/to/app/logs/*.log {
     daily
     missingok
@@ -206,7 +206,7 @@ cat > /etc/logrotate.d/url-migration << 'EOF'
     notifempty
     create 644 appuser appuser
     postrotate
-        pm2 reload url-migration-tool
+        pm2 reload smartredirect-suite
     endscript
 }
 EOF
@@ -342,7 +342,7 @@ app.get('/api/health', async (req, res) => {
 ```yaml
 # Prometheus alerting rules
 groups:
-  - name: url-migration-tool
+  - name: smartredirect-suite
     rules:
       - alert: HighMemoryUsage
         expr: (process_memory_usage_bytes / process_memory_limit_bytes) > 0.8
@@ -376,7 +376,7 @@ groups:
 #!/bin/bash
 # Backup script for production data
 
-BACKUP_DIR="/backup/url-migration/$(date +%Y%m%d_%H%M%S)"
+BACKUP_DIR="/backup/smartredirect/$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$BACKUP_DIR"
 
 # Backup application data
@@ -402,10 +402,10 @@ rm -rf "$BACKUP_DIR"
 # Disaster recovery script
 
 # Stop application
-pm2 stop url-migration-tool
+pm2 stop smartredirect-suite
 
 # Restore from backup
-BACKUP_FILE="/backup/url-migration/20240806_170000.tar.gz"
+BACKUP_FILE="/backup/smartredirect/20240806_170000.tar.gz"
 tar -xzf "$BACKUP_FILE" -C /tmp/
 
 # Restore data
@@ -413,7 +413,7 @@ cp -r /tmp/20240806_170000/data ./data
 cp -r /tmp/20240806_170000/logs ./logs
 
 # Restart application
-pm2 start url-migration-tool
+pm2 start smartredirect-suite
 
 # Verify health
 sleep 10
@@ -472,7 +472,7 @@ artillery run load-test.yml
    pm2 monit
    
    # Restart if necessary
-   pm2 restart url-migration-tool
+   pm2 restart smartredirect-suite
    ```
 
 2. **Slow Performance**
@@ -523,4 +523,4 @@ artillery run load-test.yml
 - Comprehensive validation layer
 - Production deployment documentation
 
-This deployment guide ensures enterprise-level reliability, security, and performance for the URL migration tool in production environments.
+This deployment guide ensures enterprise-level reliability, security, and performance for the SmartRedirect Suite in production environments.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,4 +1,4 @@
-# 🚀 Schnellstart-Anleitung - URL Migration App
+# 🚀 Schnellstart-Anleitung - SmartRedirect Suite
 
 > **Hinweis**: Diese Schnellstart-Anleitung bietet eine vereinfachte Installation. Für detaillierte Informationen siehe [README.md](./README.md). Für Enterprise-Deployments konsultieren Sie [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md).
 

--- a/OPENSHIFT_DEPLOYMENT.md
+++ b/OPENSHIFT_DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# OpenShift Deployment Guide - URL Migration Tool
+# OpenShift Deployment Guide - SmartRedirect Suite
 
 > **Zielgruppe**: OpenShift-Administratoren und DevOps-Engineers. Für Standard-Installation siehe [INSTALLATION.md](./INSTALLATION.md). Für Enterprise-Features konsultieren Sie [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md).
 
@@ -10,7 +10,7 @@
 
 ## Überblick
 
-Diese Anleitung beschreibt die Bereitstellung der URL Migration Tool Anwendung auf OpenShift mit persistenter Datenspeicherung und produktionstauglicher Konfiguration.
+Diese Anleitung beschreibt die Bereitstellung der SmartRedirect Suite Anwendung auf OpenShift mit persistenter Datenspeicherung und produktionstauglicher Konfiguration.
 
 ## Voraussetzungen
 
@@ -30,22 +30,22 @@ Diese Anleitung beschreibt die Bereitstellung der URL Migration Tool Anwendung a
 ### OpenShift-Projekt erstellen
 ```bash
 # Neues Projekt erstellen
-oc new-project url-migration-tool
+oc new-project smartredirect-suite
 
 # Projekt als aktiv setzen
-oc project url-migration-tool
+oc project smartredirect-suite
 
 # Labels für bessere Organisation
-oc label namespace url-migration-tool app=url-migration-tool
+oc label namespace smartredirect-suite app=smartredirect-suite
 ```
 
 ### Service Account konfigurieren
 ```bash
 # Service Account für die Anwendung erstellen
-oc create serviceaccount url-migration-sa
+oc create serviceaccount smartredirect-sa
 
 # Berechtigung für Persistent Volumes
-oc adm policy add-scc-to-user anyuid -z url-migration-sa
+oc adm policy add-scc-to-user anyuid -z smartredirect-sa
 ```
 
 ## 2. Persistent Storage konfigurieren
@@ -60,8 +60,8 @@ oc adm policy add-scc-to-user anyuid -z url-migration-sa
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: url-migration-data-pvc
-  namespace: url-migration-tool
+  name: smartredirect-data-pvc
+  namespace: smartredirect-suite
 spec:
   accessModes:
     - ReadWriteOnce
@@ -92,12 +92,12 @@ oc get storageclass
 ### Application Secrets erstellen
 ```bash
 # Admin-Passwort und Session-Secret erstellen
-oc create secret generic url-migration-secrets \
+oc create secret generic smartredirect-secrets \
   --from-literal=ADMIN_PASSWORD='IhrSicheresPasswort123!' \
   --from-literal=SESSION_SECRET='super-geheimer-session-schluessel-mindestens-64-zeichen-lang-fuer-produktion'
 
 # Optional: TLS-Zertifikate für HTTPS
-oc create secret tls url-migration-tls \
+oc create secret tls smartredirect-tls \
   --cert=path/to/tls.crt \
   --key=path/to/tls.key
 ```
@@ -145,15 +145,15 @@ Die Anwendung **erkennt automatisch** die Umgebung und verwendet die korrekten W
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: url-migration-config
-  namespace: url-migration-tool
+  name: smartredirect-config
+  namespace: smartredirect-suite
 data:
   NODE_ENV: "production"
   PORT: "5000"
   # Upload-Pfad (von der Anwendung unterstützt)
   LOCAL_UPLOAD_PATH: "/app/uploads"
   # Cookie-Domain für Production (optional)
-  COOKIE_DOMAIN: "url-migration-tool-url-migration-tool.apps.cluster.example.com"
+  COOKIE_DOMAIN: "smartredirect-suite-smartredirect-suite.apps.cluster.example.com"
 ```
 
 ```bash
@@ -203,13 +203,13 @@ CMD ["npm", "start"]
 ### Image erstellen und pushen
 ```bash
 # Image lokal erstellen
-docker build -t url-migration-tool:latest .
+docker build -t smartredirect-suite:latest .
 
 # Image taggen für Registry
-docker tag url-migration-tool:latest quay.io/yourorg/url-migration-tool:v1.4
+docker tag smartredirect-suite:latest quay.io/yourorg/smartredirect-suite:v1.4
 
 # Image zur Registry pushen
-docker push quay.io/yourorg/url-migration-tool:v1.4
+docker push quay.io/yourorg/smartredirect-suite:v1.4
 ```
 
 ## 5. Deployment konfigurieren
@@ -220,26 +220,26 @@ docker push quay.io/yourorg/url-migration-tool:v1.4
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: url-migration-tool
-  namespace: url-migration-tool
+  name: smartredirect-suite
+  namespace: smartredirect-suite
   labels:
-    app: url-migration-tool
+    app: smartredirect-suite
     version: v1.4
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: url-migration-tool
+      app: smartredirect-suite
   template:
     metadata:
       labels:
-        app: url-migration-tool
+        app: smartredirect-suite
         version: v1.4
     spec:
-      serviceAccountName: url-migration-sa
+      serviceAccountName: smartredirect-sa
       containers:
-      - name: url-migration-tool
-        image: quay.io/yourorg/url-migration-tool:v1.4
+      - name: smartredirect-suite
+        image: quay.io/yourorg/smartredirect-suite:v1.4
         ports:
         - containerPort: 5000
           protocol: TCP
@@ -247,32 +247,32 @@ spec:
         - name: NODE_ENV
           valueFrom:
             configMapKeyRef:
-              name: url-migration-config
+              name: smartredirect-config
               key: NODE_ENV
         - name: PORT
           valueFrom:
             configMapKeyRef:
-              name: url-migration-config
+              name: smartredirect-config
               key: PORT
         - name: ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: url-migration-secrets
+              name: smartredirect-secrets
               key: ADMIN_PASSWORD
         - name: SESSION_SECRET
           valueFrom:
             secretKeyRef:
-              name: url-migration-secrets
+              name: smartredirect-secrets
               key: SESSION_SECRET
         - name: LOCAL_UPLOAD_PATH
           valueFrom:
             configMapKeyRef:
-              name: url-migration-config
+              name: smartredirect-config
               key: LOCAL_UPLOAD_PATH
         - name: COOKIE_DOMAIN
           valueFrom:
             configMapKeyRef:
-              name: url-migration-config
+              name: smartredirect-config
               key: COOKIE_DOMAIN
         # Persistente Volume Mounts
         # Wichtig: Die Anwendung verwendet fest codierte Pfade relativ zum Arbeitsverzeichnis
@@ -319,7 +319,7 @@ spec:
       volumes:
       - name: data-storage
         persistentVolumeClaim:
-          claimName: url-migration-data-pvc
+          claimName: smartredirect-data-pvc
       # Restart Policy
       restartPolicy: Always
 ```
@@ -337,13 +337,13 @@ oc apply -f deployment.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: url-migration-tool-service
-  namespace: url-migration-tool
+  name: smartredirect-suite-service
+  namespace: smartredirect-suite
   labels:
-    app: url-migration-tool
+    app: smartredirect-suite
 spec:
   selector:
-    app: url-migration-tool
+    app: smartredirect-suite
   ports:
   - name: http
     port: 80
@@ -358,15 +358,15 @@ spec:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: url-migration-tool-route
-  namespace: url-migration-tool
+  name: smartredirect-suite-route
+  namespace: smartredirect-suite
   labels:
-    app: url-migration-tool
+    app: smartredirect-suite
 spec:
-  host: url-migration-tool-url-migration-tool.apps.cluster.example.com
+  host: smartredirect-suite-smartredirect-suite.apps.cluster.example.com
   to:
     kind: Service
-    name: url-migration-tool-service
+    name: smartredirect-suite-service
     weight: 100
   port:
     targetPort: http
@@ -390,14 +390,14 @@ oc apply -f route.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: url-migration-tool-monitor
-  namespace: url-migration-tool
+  name: smartredirect-suite-monitor
+  namespace: smartredirect-suite
   labels:
-    app: url-migration-tool
+    app: smartredirect-suite
 spec:
   selector:
     matchLabels:
-      app: url-migration-tool
+      app: smartredirect-suite
   endpoints:
   - port: http
     path: /api/metrics
@@ -407,10 +407,10 @@ spec:
 ### Logging-Konfiguration
 ```bash
 # Log-Aggregation mit EFK Stack
-oc label pod -l app=url-migration-tool logging=enabled
+oc label pod -l app=smartredirect-suite logging=enabled
 
 # Logs anzeigen
-oc logs -f deployment/url-migration-tool
+oc logs -f deployment/smartredirect-suite
 ```
 
 ## 8. Backup-Strategie
@@ -422,8 +422,8 @@ cat > backup-job.yaml << 'EOF'
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: url-migration-backup
-  namespace: url-migration-tool
+  name: smartredirect-backup
+  namespace: smartredirect-suite
 spec:
   schedule: "0 2 * * *"  # Täglich um 2:00 Uhr
   jobTemplate:
@@ -438,7 +438,7 @@ spec:
             - -c
             - |
               echo "Starting backup at $(date)"
-              tar -czf /backup/url-migration-$(date +%Y%m%d).tar.gz -C /app data
+              tar -czf /backup/smartredirect-$(date +%Y%m%d).tar.gz -C /app data
               echo "Backup completed at $(date)"
             volumeMounts:
             - name: data-storage
@@ -449,10 +449,10 @@ spec:
           volumes:
           - name: data-storage
             persistentVolumeClaim:
-              claimName: url-migration-data-pvc
+              claimName: smartredirect-data-pvc
           - name: upload-storage
             persistentVolumeClaim:
-              claimName: url-migration-uploads-pvc
+              claimName: smartredirect-uploads-pvc
           - name: backup-storage
             persistentVolumeClaim:
               claimName: backup-pvc  # Zusätzlich zu erstellen
@@ -469,7 +469,7 @@ oc apply -f backup-job.yaml
 # 1. Alle Konfigurationen anwenden
 oc apply -f pvc-data.yaml
 oc apply -f configmap.yaml
-oc create secret generic url-migration-secrets \
+oc create secret generic smartredirect-secrets \
   --from-literal=ADMIN_PASSWORD='IhrSicheresPasswort123!' \
   --from-literal=SESSION_SECRET='super-geheimer-session-schluessel-mindestens-64-zeichen-lang'
 
@@ -479,18 +479,18 @@ oc apply -f service.yaml
 oc apply -f route.yaml
 
 # 3. Deployment-Status prüfen
-oc get pods -l app=url-migration-tool
+oc get pods -l app=smartredirect-suite
 oc get pvc
 oc get routes
 
 # 4. Logs prüfen
-oc logs -f deployment/url-migration-tool
+oc logs -f deployment/smartredirect-suite
 ```
 
 ### Verification und Testing
 ```bash
 # Route URL ermitteln
-ROUTE_URL=$(oc get route url-migration-tool-route -o jsonpath='{.spec.host}')
+ROUTE_URL=$(oc get route smartredirect-suite-route -o jsonpath='{.spec.host}')
 echo "Application URL: https://$ROUTE_URL"
 
 # Health Check
@@ -510,13 +510,13 @@ curl -X POST https://$ROUTE_URL/api/admin/auth \
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: url-migration-tool-hpa
-  namespace: url-migration-tool
+  name: smartredirect-suite-hpa
+  namespace: smartredirect-suite
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: url-migration-tool
+    name: smartredirect-suite
   minReplicas: 2
   maxReplicas: 10
   metrics:
@@ -537,14 +537,14 @@ spec:
 ### Performance-Tuning
 ```bash
 # Resource-Limits anpassen für High-Load
-oc patch deployment url-migration-tool -p='
+oc patch deployment smartredirect-suite -p='
 {
   "spec": {
     "template": {
       "spec": {
         "containers": [
           {
-            "name": "url-migration-tool",
+            "name": "smartredirect-suite",
             "resources": {
               "limits": {
                 "memory": "1Gi",
@@ -570,14 +570,14 @@ oc patch deployment url-migration-tool -p='
 **Pod startet nicht:**
 ```bash
 # Events prüfen
-oc describe pod -l app=url-migration-tool
+oc describe pod -l app=smartredirect-suite
 
 # Logs anzeigen
-oc logs -l app=url-migration-tool --previous
+oc logs -l app=smartredirect-suite --previous
 
 # Storage-Probleme prüfen
 oc get pvc
-oc describe pvc url-migration-data-pvc
+oc describe pvc smartredirect-data-pvc
 ```
 
 **Persistente Daten gehen verloren:**
@@ -586,16 +586,16 @@ oc describe pvc url-migration-data-pvc
 oc get pvc -o wide
 
 # Volume-Mounts verifizieren
-oc describe pod -l app=url-migration-tool | grep -A5 "Mounts:"
+oc describe pod -l app=smartredirect-suite | grep -A5 "Mounts:"
 
 # Datei-Berechtigungen prüfen
-oc exec -it deployment/url-migration-tool -- ls -la /app/
+oc exec -it deployment/smartredirect-suite -- ls -la /app/
 ```
 
 **Performance-Probleme:**
 ```bash
 # Resource-Verbrauch überwachen
-oc top pods -l app=url-migration-tool
+oc top pods -l app=smartredirect-suite
 
 # Metriken prüfen
 curl https://$ROUTE_URL/api/metrics
@@ -606,25 +606,25 @@ curl https://$ROUTE_URL/api/metrics
 ### Rolling Updates
 ```bash
 # Neues Image deployen
-oc set image deployment/url-migration-tool \
-  url-migration-tool=quay.io/yourorg/url-migration-tool:v1.5
+oc set image deployment/smartredirect-suite \
+  smartredirect-suite=quay.io/yourorg/smartredirect-suite:v1.5
 
 # Update-Status verfolgen
-oc rollout status deployment/url-migration-tool
+oc rollout status deployment/smartredirect-suite
 
 # Rollback bei Problemen
-oc rollout undo deployment/url-migration-tool
+oc rollout undo deployment/smartredirect-suite
 ```
 
 ### Wartungs-Fenster
 ```bash
 # Wartungsmodus aktivieren (Replicas auf 0)
-oc scale deployment url-migration-tool --replicas=0
+oc scale deployment smartredirect-suite --replicas=0
 
 # Wartungsarbeiten durchführen...
 
 # Service wieder aktivieren
-oc scale deployment url-migration-tool --replicas=2
+oc scale deployment smartredirect-suite --replicas=2
 ```
 
 ## 13. Sicherheit
@@ -635,7 +635,7 @@ oc scale deployment url-migration-tool --replicas=2
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: url-migration-scc
+  name: smartredirect-scc
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
@@ -653,7 +653,7 @@ runAsUser:
 seLinuxContext:
   type: MustRunAs
 users:
-- system:serviceaccount:url-migration-tool:url-migration-sa
+- system:serviceaccount:smartredirect-suite:smartredirect-sa
 ```
 
 ### Network Policies
@@ -662,12 +662,12 @@ users:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: url-migration-netpol
-  namespace: url-migration-tool
+  name: smartredirect-netpol
+  namespace: smartredirect-suite
 spec:
   podSelector:
     matchLabels:
-      app: url-migration-tool
+      app: smartredirect-suite
   policyTypes:
   - Ingress
   - Egress
@@ -688,19 +688,19 @@ spec:
 ### Hilfreiche OpenShift-Kommandos
 ```bash
 # Projekt-Ressourcen anzeigen
-oc get all -l app=url-migration-tool
+oc get all -l app=smartredirect-suite
 
 # Deployment-Details
-oc describe deployment url-migration-tool
+oc describe deployment smartredirect-suite
 
 # Pod-Logs live verfolgen
-oc logs -f deployment/url-migration-tool
+oc logs -f deployment/smartredirect-suite
 
 # In Pod einloggen für Debugging
-oc exec -it deployment/url-migration-tool -- /bin/bash
+oc exec -it deployment/smartredirect-suite -- /bin/bash
 
 # Port-Forwarding für lokale Tests
-oc port-forward service/url-migration-tool-service 8080:80
+oc port-forward service/smartredirect-suite-service 8080:80
 ```
 
 ### Ressourcen-Übersicht
@@ -718,4 +718,4 @@ Nach erfolgreichem Deployment haben Sie folgende Ressourcen:
 - **Anwendungssupport**: Siehe [README.md](./README.md)
 - **API-Integration**: Siehe [API_DOCUMENTATION.md](./API_DOCUMENTATION.md)
 
-Diese Anleitung stellt eine produktionstaugliche Bereitstellung der URL Migration Tool Anwendung auf OpenShift sicher, mit allen notwendigen Sicherheits- und Persistierung-Features.
+Diese Anleitung stellt eine produktionstaugliche Bereitstellung der SmartRedirect Suite Anwendung auf OpenShift sicher, mit allen notwendigen Sicherheits- und Persistierung-Features.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# URL Migration Application
+# SmartRedirect Suite
 
-**Version 1.0.0** - Eine deutsche Web-Anwendung zur Verwaltung von URL-Migrationen zwischen alter und neuer Domain mit erweiterten Admin-Funktionen und intelligenter Regel-Verwaltung.
+**Version 1.0.0** – SmartRedirect Suite ist eine deutsche Web-Anwendung zur Verwaltung von URL-Migrationen zwischen alter und neuer Domain mit erweiterten Admin-Funktionen und intelligenter Regel-Verwaltung.
 
 ## 📋 Überblick
 
@@ -30,7 +30,7 @@ npm --version
 ```bash
 # Repository klonen (ersetzen Sie <repository-url> mit der tatsächlichen URL)
 git clone <repository-url>
-cd url-migration-app
+cd SmartRedirectSuite
 ```
 
 ### Schritt 2: Dependencies installieren
@@ -173,7 +173,7 @@ Diese Anwendung verfügt über umfassende Dokumentation für verschiedene Anwend
 ## 📁 Projektstruktur
 
 ```
-url-migration-app/
+SmartRedirectSuite/
 ├── client/                 # Frontend (React + TypeScript)
 │   ├── src/
 │   │   ├── components/     # UI-Komponenten

--- a/replit.md
+++ b/replit.md
@@ -1,6 +1,6 @@
 ## Overview
 
-**Version 1.0.0** - This is a production-ready Node.js web application designed for URL migration. It guides users from outdated links on an old domain to equivalent new URLs. The application presents a migration page with the new URL, offering options to copy or navigate. It includes an admin panel for managing URL transformation rules, tracking migration statistics, and customizing the user experience. The project provides a robust, enterprise-grade solution for seamless web migrations with comprehensive deployment documentation.
+**Version 1.0.0** - SmartRedirect Suite is a production-ready Node.js web application designed for URL migration. It guides users from outdated links on an old domain to equivalent new URLs. The application presents a migration page with the new URL, offering options to copy or navigate. It includes an admin panel for managing URL transformation rules, tracking migration statistics, and customizing the user experience. The project provides a robust, enterprise-grade solution for seamless web migrations with comprehensive deployment documentation.
 
 ## User Preferences
 


### PR DESCRIPTION
## Summary
- update documentation to reflect the new SmartRedirect Suite name
- adjust examples and project paths for SmartRedirect Suite

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS2322 errors in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6896026910e08331b12ee7d2114c0528