### PR TITLE
Remove referrer tracking

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -108,8 +108,7 @@ Content-Type: application/json
   "newUrl": "https://newsite.com/articles/article-1",
   "path": "/news/article-1",
   "userAgent": "Mozilla/5.0...",
-  "referrer": "https://google.com",
-  "httpReferrer": "https://google.com"
+  "timestamp": "2025-01-06T17:30:00.000Z"
 }
 ```
 
@@ -117,8 +116,7 @@ Content-Type: application/json
 ```json
 {
   "success": true,
-  "trackingId": "tracking_uuid",
-  "timestamp": "2025-01-06T17:30:00.000Z"
+  "trackingId": "tracking_uuid"
 }
 ```
 
@@ -365,9 +363,7 @@ GET /api/admin/stats/entries
       "newUrl": "https://newsite.com/articles/article-1",
       "path": "/news/article-1",
       "timestamp": "2025-01-06T17:30:00.000Z",
-      "userAgent": "Mozilla/5.0...",
-      "referrer": "https://google.com",
-      "httpReferrer": "https://google.com"
+      "userAgent": "Mozilla/5.0..."
     }
   ],
   "pagination": {
@@ -484,7 +480,7 @@ Content-Type: application/json
 Content-Type: text/csv
 Content-Disposition: attachment; filename="url-statistics-20250106.csv"
 
-Alte URL,Neue URL,Pfad,Zeitstempel,User-Agent,HTTP-Referrer
+Alte URL,Neue URL,Pfad,Zeitstempel,User-Agent,Referrer
 "https://oldsite.com/news/","https://newsite.com/articles/","/news/","2025-01-06T17:30:00.000Z","Mozilla/5.0...","https://google.com"
 ```
 
@@ -496,8 +492,7 @@ Alte URL,Neue URL,Pfad,Zeitstempel,User-Agent,HTTP-Referrer
     "newUrl": "https://newsite.com/articles/",
     "path": "/news/",
     "timestamp": "2025-01-06T17:30:00.000Z",
-    "userAgent": "Mozilla/5.0...",
-    "httpReferrer": "https://google.com"
+    "userAgent": "Mozilla/5.0..."
   }
 ]
 ```

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -49,7 +49,6 @@ import {
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
-  ArrowLeftRight,
   AlertTriangle,
   Info,
 } from "lucide-react";
@@ -225,10 +224,10 @@ export default function AdminPage({ onClose }: AdminPageProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState('timestamp');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
-  const [statsView, setStatsView] = useState<'top100' | 'referrers' | 'browser'>(() => {
+  const [statsView, setStatsView] = useState<'top100' | 'browser'>(() => {
     // Only restore stats view if we're explicitly showing admin view
     const showAdmin = localStorage.getItem('showAdminView') === 'true';
-    return showAdmin ? ((localStorage.getItem('adminStatsView') as 'top100' | 'referrers' | 'browser') || 'top100') : 'top100';
+    return showAdmin ? ((localStorage.getItem('adminStatsView') as 'top100' | 'browser') || 'top100') : 'top100';
   });
   const [activeTab, setActiveTab] = useState(() => {
     // Only restore admin tab if we're explicitly showing admin view
@@ -255,7 +254,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
   };
 
   // Save stats view to localStorage when it changes
-  const handleStatsViewChange = (newView: 'top100' | 'referrers' | 'browser') => {
+  const handleStatsViewChange = (newView: 'top100' | 'browser') => {
     setStatsView(newView);
     localStorage.setItem('adminStatsView', newView);
   };
@@ -388,26 +387,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
     },
   });
 
-  // Top Referrers - all entries (non-paginated)  
-  const { data: referrersPagedData, isLoading: referrersLoading } = useQuery<Array<{ referrer: string; count: number }>>({
-    queryKey: ["/api/admin/stats/referrers", statsFilter],
-    enabled: isAuthenticated && statsView === 'referrers',
-    retry: false,
-    queryFn: async () => {
-      const params = new URLSearchParams();
-      if (statsFilter !== 'all') {
-        params.append('timeRange', statsFilter);
-      }
-      const url = `/api/admin/stats/referrers${params.toString() ? '?' + params.toString() : ''}`;
-      const response = await fetch(url, { credentials: 'include' });
-      if (response.status === 401 || response.status === 403) {
-        setIsAuthenticated(false);
-        throw new Error('Authentication required');
-      }
-      if (!response.ok) throw new Error('Failed to fetch referrers');
-      return response.json();
-    },
-  });
 
   // Paginated tracking entries with search and sort
   const { data: paginatedEntriesData, isLoading: entriesLoading } = useQuery({
@@ -913,8 +892,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
   const statsEndIndex = statsStartIndex + trackingEntries.length;
 
   // Add missing variables for UI display
-  const totalReferrers = referrersPagedData?.length || 0;
-  const totalReferrersPages = 1; // Since we're not paginating referrers anymore
   const totalTopUrls = topUrlsData?.length || 0;
   const totalTopUrlsPages = 1; // Since we're not paginating top URLs anymore
 
@@ -2819,14 +2796,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                     Top 100
                   </Button>
                   <Button
-                    variant={statsView === 'referrers' ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => handleStatsViewChange('referrers')}
-                  >
-                    <ArrowLeftRight className="h-4 w-4 mr-2" />
-                    Top 100 Referrer
-                  </Button>
-                  <Button
                     variant={statsView === 'browser' ? 'default' : 'outline'}
                     size="sm"
                     onClick={() => handleStatsViewChange('browser')}
@@ -2835,9 +2804,8 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                     Alle Einträge
                   </Button>
                 </div>
-
-                {/* Time filter for top100 and referrers */}
-                {(statsView === 'top100' || statsView === 'referrers') && (
+                {/* Time filter for top100 */}
+                {statsView === 'top100' && (
                   <Select value={statsFilter} onValueChange={(value) => setStatsFilter(value as '24h' | '7d' | 'all')}>
                     <SelectTrigger className="w-auto">
                       <SelectValue />
@@ -2866,7 +2834,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                 )}
 
                 {/* Search and pagination info for paginated views */}
-                {(statsView === 'top100' || statsView === 'referrers' || statsView === 'browser') && (
+                {(statsView === 'top100' || statsView === 'browser') && (
                   <div className="flex justify-between items-center text-sm text-muted-foreground mt-4">
                     <div>
                       {statsView === 'top100' && (
@@ -2874,13 +2842,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                           "Lade URLs..."
                         ) : (
                           `${totalTopUrls} URL${totalTopUrls !== 1 ? 's' : ''} insgesamt`
-                        )
-                      )}
-                      {statsView === 'referrers' && (
-                        referrersLoading ? (
-                          "Lade Referrer..."
-                        ) : (
-                          `${totalReferrers} Referrer insgesamt`
                         )
                       )}
                       {statsView === 'browser' && (
@@ -2896,10 +2857,9 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                         <span className="ml-2 text-xs text-blue-600 dark:text-blue-400">Suche...</span>
                       )}
                     </div>
-                    {!entriesLoading && !top100Loading && !referrersLoading && (
+                    {!entriesLoading && !top100Loading && (
                       <div>
                         {statsView === 'top100' && totalTopUrlsPages > 1 && `Seite ${statsPage} von ${totalTopUrlsPages}`}
-                        {statsView === 'referrers' && totalReferrersPages > 1 && `Seite ${statsPage} von ${totalReferrersPages}`}
                         {statsView === 'browser' && totalStatsPages > 1 && `Seite ${statsPage} von ${totalStatsPages}`}
                       </div>
                     )}
@@ -2952,71 +2912,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                                         </div>
                                         <span className="text-xs text-muted-foreground">
                                           {((url.count / maxCount) * 100).toFixed(1)}%
-                                        </span>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                );
-                              })}
-                            </tbody>
-                          </table>
-                        </div>
-
-                      </>
-                    )}
-                  </CardContent>
-                </Card>
-              )}
-
-              {/* Top 100 Referrers View */}
-              {statsView === 'referrers' && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Top Referrer</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    {referrersLoading ? (
-                      <div className="text-center py-8">Lade Referrer-Statistiken...</div>
-                    ) : !referrersPagedData?.length ? (
-                      <div className="text-center py-8 text-muted-foreground">
-                        Keine Referrer-Daten vorhanden.
-                      </div>
-                    ) : (
-                      <>
-                        <div className="overflow-hidden">
-                          <table className="w-full">
-                            <thead className="bg-muted/50 border-b">
-                              <tr>
-                                <th className="text-left p-3 font-medium">Rang</th>
-                                <th className="text-left p-3 font-medium">HTTP Referrer</th>
-                                <th className="text-right p-3 font-medium">Aufrufe</th>
-                                <th className="text-left p-3 font-medium">Anteil</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {referrersPagedData.map((referrer: any, index: number) => {
-                                const rank = index + 1;
-                                const maxCount = referrersPagedData[0]?.count || 1;
-                                return (
-                                  <tr key={index} className="border-b hover:bg-muted/50">
-                                    <td className="p-3 text-sm font-medium">#{rank}</td>
-                                    <td className="p-3">
-                                      <code className="text-sm text-foreground break-all">
-                                        {referrer.referrer === 'Direkt' ? (
-                                          <span className="text-muted-foreground">Direkt (kein Referrer)</span>
-                                        ) : (
-                                          referrer.referrer
-                                        )}
-                                      </code>
-                                    </td>
-                                    <td className="p-3 text-right text-sm font-medium">{referrer.count}</td>
-                                    <td className="p-3">
-                                      <div className="flex items-center gap-2">
-                                        <div className="w-16">
-                                          <Progress value={(referrer.count / maxCount) * 100} className="h-2" />
-                                        </div>
-                                        <span className="text-xs text-muted-foreground">
-                                          {((referrer.count / maxCount) * 100).toFixed(1)}%
                                         </span>
                                       </div>
                                     </td>
@@ -3096,17 +2991,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                                     {getSortIcon('path')}
                                   </Button>
                                 </th>
-                                <th className="text-left p-3">
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => handleSort('httpReferrer')}
-                                    className="h-auto p-0 font-medium hover:bg-transparent"
-                                  >
-                                    HTTP Referer
-                                    {getSortIcon('httpReferrer')}
-                                  </Button>
-                                </th>
                               </tr>
                             </thead>
                             <tbody>
@@ -3127,9 +3011,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                                   </td>
                                   <td className="p-3">
                                     <code className="text-sm text-foreground">{entry.path}</code>
-                                  </td>
-                                  <td className="p-3 text-xs text-muted-foreground max-w-xs truncate">
-                                    {entry.httpReferrer || 'Direkt'}
                                   </td>
                                 </tr>
                               ))}

--- a/client/src/pages/migration.tsx
+++ b/client/src/pages/migration.tsx
@@ -187,7 +187,6 @@ export default function MigrationPage({ onAdminAccess }: MigrationPageProps) {
               path: path,
               timestamp: new Date().toISOString(),
               userAgent: navigator.userAgent,
-              referrer: document.referrer || undefined,
             }),
           });
           

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -132,13 +132,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/track", async (req, res) => {
     try {
       const trackingData = insertUrlTrackingSchema.parse(req.body);
-      // Add HTTP Referer from request headers
-      const httpReferrer = req.get('Referer') || req.get('Referrer') || undefined;
-      const trackingWithReferer = {
-        ...trackingData,
-        httpReferrer
-      };
-      const tracking = await storage.trackUrlAccess(trackingWithReferer);
+      const tracking = await storage.trackUrlAccess(trackingData);
       res.json(tracking);
     } catch (error) {
       console.error("Tracking error:", error);
@@ -425,19 +419,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // Top 100 Referrers
-  app.get("/api/admin/stats/referrers", requireAuth, async (req, res) => {
-    try {
-      const timeRange = req.query.timeRange as '24h' | '7d' | 'all' | undefined;
-      const topReferrers = await storage.getTopReferrers(100, timeRange);
-      
-      res.json(topReferrers);
-    } catch (error) {
-      console.error("Top referrers stats error:", error);
-      res.status(500).json({ error: "Failed to fetch referrer statistics" });
-    }
-  });
-
   // Comprehensive tracking entries with search and sort
   app.get("/api/admin/stats/entries", requireAuth, async (req, res) => {
     try {
@@ -477,26 +458,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const page = parseInt(req.query.page as string) || 1;
       const limit = parseInt(req.query.limit as string) || 50;
       const timeRange = req.query.timeRange as '24h' | '7d' | 'all' | undefined;
-      
+
       const result = await storage.getTopUrlsPaginated(page, limit, timeRange);
       res.json(result);
     } catch (error) {
       console.error("Paginated top URLs error:", error);
       res.status(500).json({ error: "Failed to fetch paginated top URLs" });
-    }
-  });
-
-  app.get("/api/admin/stats/referrers/paginated", requireAuth, async (req, res) => {
-    try {
-      const page = parseInt(req.query.page as string) || 1;
-      const limit = parseInt(req.query.limit as string) || 50;
-      const timeRange = req.query.timeRange as '24h' | '7d' | 'all' | undefined;
-      
-      const result = await storage.getTopReferrersPaginated(page, limit, timeRange);
-      res.json(result);
-    } catch (error) {
-      console.error("Paginated referrers error:", error);
-      res.status(500).json({ error: "Failed to fetch paginated referrers" });
     }
   });
 
@@ -509,10 +476,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const trackingData = await storage.getTrackingData(exportRequest.timeRange);
         
         if (exportRequest.format === 'csv') {
-          // CSV-Export with ALL fields
-          const csvHeader = 'ID,Alte URL,Neue URL,Pfad,Zeitstempel,User-Agent,Referrer,HTTP-Referrer\n';
-          const csvData = trackingData.map(track => 
-            `"${track.id}","${track.oldUrl}","${(track as any).newUrl || ''}","${track.path}","${track.timestamp}","${track.userAgent || ''}","${track.referrer || ''}","${(track as any).httpReferrer || ''}"`
+          // CSV-Export without referrer
+          const csvHeader = 'ID,Alte URL,Neue URL,Pfad,Zeitstempel,User-Agent\n';
+          const csvData = trackingData.map(track =>
+            `"${track.id}","${track.oldUrl}","${(track as any).newUrl || ''}","${track.path}","${track.timestamp}","${track.userAgent || ''}"`
           ).join('\n');
           
           res.setHeader('Content-Type', 'text/csv');

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -71,12 +71,6 @@ export const urlTrackingSchema = z.object({
   userAgent: z.string()
     .max(1000, "User agent too long")
     .optional(),
-  referrer: z.string()
-    .max(2000, "Referrer too long")
-    .optional(),
-  httpReferrer: z.string()
-    .max(2000, "HTTP referrer too long")
-    .optional(),
 }).strict();
 
 export const insertUrlTrackingSchema = urlTrackingSchema.omit({


### PR DESCRIPTION
## Summary
- drop referrer field from tracking schema and docs
- remove referrer stats endpoints and admin dashboard view
- exclude referrer from tracking and export paths

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_6896017610c08331a9772cbbe73f3a69