### PR TITLE
Disable API caching to avoid 304 responses

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,11 @@ import { setupVite, serveStatic, log } from "./vite";
 import { FileSessionStore } from "./fileSessionStore";
 
 const app = express();
+app.disable('etag');
+app.use('/api', (_req, res, next) => {
+  res.set('Cache-Control', 'no-store');
+  next();
+});
 
 // Trust proxy settings for production deployment behind reverse proxies
 // This is essential for proper HTTPS detection and secure cookies


### PR DESCRIPTION
## Summary
- disable ETag generation and caching for API routes to ensure fresh responses for authenticated requests

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68961df1d4bc8331a5e1ad3f18758f69