### PR TITLE
docs: add documentation index and guides

### DIFF
--- a/ADMIN_DOCUMENTATION.md
+++ b/ADMIN_DOCUMENTATION.md
@@ -1,0 +1,14 @@
+# SmartRedirect Suite - Admin-Dokumentation
+
+Diese Dokumentation richtet sich an Administratoren und DevOps-Teams. Sie bündelt Ressourcen für Installation, Deployment und den laufenden Betrieb.
+
+## Installations- und Deployment-Ressourcen
+- [INSTALLATION.md](./INSTALLATION.md): Schnellstart für lokale Entwicklung.
+- [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md): Leitfaden für Produktionsumgebungen.
+- [OPENSHIFT_DEPLOYMENT.md](./OPENSHIFT_DEPLOYMENT.md): Beispielkonfiguration für OpenShift.
+- [API_DOCUMENTATION.md](./API_DOCUMENTATION.md): REST-API für Automatisierung und Monitoring.
+
+## Wartung
+- Regelmäßige Backups der `data/`-Verzeichnisse.
+- Abgelaufene Sessions unter `data/sessions/` bereinigen.
+- Logs und Performance-Metriken gemäß Deployment-Guides überwachen.

--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,15 @@
+# SmartRedirect Suite - Architektur-Übersicht
+
+Die Anwendung ist modular aufgebaut und trennt klar zwischen Frontend, Backend und gemeinsam genutzten Typen.
+
+## Komponenten
+- **client/**: React 18 + TypeScript Frontend, gebündelt mit Vite.
+- **server/**: Express-basiertes Backend mit Dateispeicher und Session-Handling.
+- **shared/**: Gemeinsame TypeScript-Typen und Validierungsschemata.
+
+## Ablauf
+1. Anfragen erreichen das `server/`-Modul und prüfen Regeln aus `data/`.
+2. Validierte Daten werden an das `client/`-Frontend ausgeliefert.
+3. `shared/` stellt Typdefinitionen und Zod-Schemas für beide Seiten bereit.
+
+Die Architektur ermöglicht die Verarbeitung von über 100.000 Regeln und Log-Einträgen mit Fokus auf Performance und Nachvollziehbarkeit.

--- a/CONFIGURATION_EXAMPLES.md
+++ b/CONFIGURATION_EXAMPLES.md
@@ -1,0 +1,25 @@
+# SmartRedirect Suite - Konfigurationsbeispiele
+
+## .env Beispiel
+```bash
+ADMIN_PASSWORD=MeinSicheresPasswort123
+SESSION_SECRET=super-geheimer-session-schluessel-hier-einfuegen-mindestens-32-zeichen
+PORT=5000
+NODE_ENV=development
+```
+
+## Beispiel-Regeln
+Die Datei [sample-rules-import.json](./sample-rules-import.json) zeigt den Aufbau einer Regeldatei:
+
+```json
+{
+  "rules": [
+    {
+      "matcher": "/alte-seite/",
+      "targetUrl": "/neue-seite/",
+      "type": "redirect",
+      "infoText": "Diese Seite wurde verschoben"
+    }
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ SmartRedirect Suite ist eine Web-Anwendung zur zentralen Verwaltung von URL‑Mi
 
 ## Inhaltsverzeichnis
 - [Key Features](#key-features)
+- [Dokumentation](#dokumentation)
 - [Impressions](#impressions)
 - [Funktionsweise](#funktionsweise)
   - [Regelmodi](#regelmodi)
@@ -35,6 +36,12 @@ SmartRedirect Suite ist eine Web-Anwendung zur zentralen Verwaltung von URL‑Mi
 - Intelligente Validierung mit Überlappungserkennung
 - Umfangreiche Statistiken und URL-Tracking
 - Responsives Design für Desktop und Mobilgeräte
+
+## Dokumentation
+- [Benutzerhandbuch](./USER_MANUAL.md)
+- [Admin-Dokumentation](./ADMIN_DOCUMENTATION.md)
+- [Architektur-Übersicht](./ARCHITECTURE_OVERVIEW.md)
+- [Konfigurationsbeispiele](./CONFIGURATION_EXAMPLES.md)
 
 ## Impressions
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1,0 +1,22 @@
+# SmartRedirect Suite - Benutzerhandbuch
+
+Dieses Handbuch beschreibt die tägliche Nutzung der SmartRedirect Suite. Die Anwendung verwaltet mehr als 100.000 URL-Transformationsregeln und unterstützt Migrationen zwischen Domains.
+
+## Einstieg
+- Anwendung starten: `npm run dev` für Entwicklung oder `npm start` nach dem Build.
+- Admin-Login über die Hauptseite aufrufen (Standardpasswort in `.env` konfiguriert).
+
+## Regeln verwalten
+1. **Neue Regel** anlegen: URL-Matcher, Ziel-URL und Modus (*Teilweise* oder *Vollständig*) festlegen.
+2. **Auto-Redirect** optional aktivieren.
+3. **Info-Text** zur Erläuterung für Nutzer hinterlegen.
+
+## Import und Export
+- JSON-Dateien im Format von [sample-rules-import.json](./sample-rules-import.json) importieren.
+- Regeln und Statistiken als CSV oder JSON exportieren.
+
+## Monitoring
+- Statistik-Tab zeigt Zugriffszahlen, Top-URLs und Zeitraumfilter.
+- Einträge können exportiert oder zurückgesetzt werden.
+
+Weiterführende Setup-Hinweise finden sich in [INSTALLATION.md](./INSTALLATION.md).


### PR DESCRIPTION
## Summary
- add documentation section to README linking to key guides
- document user workflow, admin resources, architecture overview, and configuration examples

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68966397a9c483319f6031b58278d796