### PR TITLE
Move client build output to dist root

### DIFF
--- a/ENTERPRISE_DEPLOYMENT.md
+++ b/ENTERPRISE_DEPLOYMENT.md
@@ -131,7 +131,7 @@ server {
     # Frontend application
     location / {
         try_files $uri $uri/ /index.html;
-        root /path/to/dist/public;
+        root /path/to/dist;
     }
 }
 ```
@@ -230,8 +230,8 @@ const CDN_URL = process.env.CDN_URL || '';
 
 // Update asset URLs in production
 if (process.env.NODE_ENV === 'production') {
-  // Assets will be served from CDN
-  app.use('/assets', express.static('dist/public/assets', {
+  // Client sources will be served from CDN
+  app.use('/src', express.static('dist/src', {
     maxAge: '1y',
     etag: true,
     lastModified: true

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -68,7 +68,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(import.meta.dirname);
 
   if (!fs.existsSync(distPath)) {
     throw new Error(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,9 @@ export default defineConfig({
   },
   root: path.resolve(import.meta.dirname, "client"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(import.meta.dirname, "dist"),
     emptyOutDir: true,
+    assetsDir: "src",
   },
   server: {
     fs: {


### PR DESCRIPTION
## Summary
- build client assets into `dist` with sources in `dist/src`
- serve static files from `dist` instead of `dist/public`
- update deployment docs for new build layout

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68983e0f6d348331b790d7a83b687c83