### PR TITLE
Configure fly.io for free tier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,5 @@ FROM base
 COPY --from=build /app /app
 
 # Start the server by default, this can be overwritten at runtime
-EXPOSE 3000
+EXPOSE 5000
 CMD [ "npm", "run", "start" ]

--- a/fly.toml
+++ b/fly.toml
@@ -12,12 +12,11 @@ primary_region = 'fra'
   internal_port = 5000
   force_https = true
   auto_stop_machines = 'stop'
-  auto_start_machines = false
-  min_machines_running = 1
+  auto_start_machines = true
+  min_machines_running = 0
   processes = ['app']
 
 [[vm]]
-  memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 256


### PR DESCRIPTION
## Summary
- enable on-demand Fly.io machines and reduce memory to fit free tier
- expose port 5000 to match Fly.io configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68986749476c8331ba11c50c4495f9e3