### PR TITLE
Inject demo banner into built index via dockerfile.demo

### DIFF
--- a/dockerfile.demo
+++ b/dockerfile.demo
@@ -1,0 +1,44 @@
+# syntax = docker/dockerfile:1
+
+# Adjust NODE_VERSION as desired
+ARG NODE_VERSION=20.18.0
+FROM node:${NODE_VERSION}-slim AS base
+
+LABEL fly_launch_runtime="Node.js"
+
+# Node.js app lives here
+WORKDIR /app
+
+# Throw-away build stage to reduce size of final image
+FROM base AS build
+
+# Install packages needed to build node modules
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
+
+# Install node modules
+COPY package-lock.json package.json ./
+RUN npm ci --include=dev
+
+# Copy application code
+COPY . .
+
+# Build application and add demo banner
+RUN npm run build \
+    && printf '%s\n' '<div style="background:#fffbdd;padding:10px;text-align:center;">This is just a demo instance and will be reset every day.<br/>Admin password: <strong>Password1</strong>.<br/><a href="https://github.com/SmartRedirectSuite/SmartRedirectSuite" target="_blank" rel="noopener noreferrer">GitHub repository</a> - For any additional questions, please visit this page.</div>' > /tmp/banner.html \
+    && sed -i '/<body[^>]*>/r /tmp/banner.html' dist/public/index.html \
+    && rm /tmp/banner.html
+
+# Remove development dependencies
+RUN npm prune --omit=dev
+
+
+# Final stage for app image
+FROM base
+
+# Copy built application
+COPY --from=build /app /app
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 5000
+CMD [ "npm", "run", "start" ]


### PR DESCRIPTION
## Summary
- add a demo-warning banner injection to `dockerfile.demo`
- restore `Dockerfile` without demo banner logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899af33aa1c8331866779c476e2de0e