### PR TITLE
docs: document admin menu access

### DIFF
--- a/ADMIN_DOCUMENTATION.md
+++ b/ADMIN_DOCUMENTATION.md
@@ -2,6 +2,8 @@
 
 Diese Dokumentation richtet sich an Administratoren und DevOps-Teams. Sie bündelt Ressourcen für Installation, Deployment und den laufenden Betrieb.
 
+Der Admin-Bereich ist über das Zahnrad-Symbol der Anwendung oder durch Anhängen von `?admin=true` an die Basis-URL erreichbar.
+
 ## Installations- und Deployment-Ressourcen
 - [INSTALLATION.md](./INSTALLATION.md): Schnellstart für lokale Entwicklung.
 - [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md): Leitfaden für Produktionsumgebungen.

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -11,6 +11,8 @@
 
 The SmartRedirect Suite provides a comprehensive REST API for managing URL transformation rules, tracking migration statistics, and administering the system. This documentation covers all available endpoints with enterprise-grade features including authentication, validation, performance monitoring, and bulk operations.
 
+To open the web-based admin menu, use the gear icon in the application or append `?admin=true` to the base URL.
+
 ## Base URL
 ```
 Production: https://yourdomain.com/api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 ### Added
 - Spezifitätsbasiertes Regel-Matching mit `selectMostSpecificRule` und konfigurierbarer Gewichtung.
 - `Dockerfile.demo` mit täglichem Cron-Reset für Demo-Instanzen.
+- Hinweise zum Öffnen des Admin-Menüs in allen relevanten Dokumentationen.
 
 ## [1.0.0] - 2025-08-08
 

--- a/ENTERPRISE_DEPLOYMENT.md
+++ b/ENTERPRISE_DEPLOYMENT.md
@@ -31,6 +31,9 @@ This document provides comprehensive deployment instructions for the enterprise-
 - **Mobile-Responsive**: Optimized UI for desktop and mobile devices
 - **German Localization**: Complete German language support throughout
 
+### Admin Menu Access
+Open the administrator menu via the gear icon in the application or by appending `?admin=true` to the base URL.
+
 ## Pre-Deployment Checklist
 
 ### 1. Environment Requirements

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -43,7 +43,7 @@ npm start
 ## 4. Zugriff
 
 - **Hauptanwendung**: http://localhost:5000
-- **Admin-Panel**: http://localhost:5000 → Admin-Login klicken
+- **Admin-Panel**: http://localhost:5000 → Zahnrad-Symbol klicken oder `?admin=true` an die URL anhängen
 - **Standard Admin-Passwort**: `Password1` (ändern Sie dies in der .env-Datei!)
 - **Brute-Force-Schutz**: Nach `LOGIN_MAX_ATTEMPTS` Fehlversuchen wird die IP für `LOGIN_BLOCK_DURATION_MS` ms gesperrt (Standard: 5 Versuche/24h, anpassbar in `.env`)
 

--- a/OPENSHIFT_DEPLOYMENT.md
+++ b/OPENSHIFT_DEPLOYMENT.md
@@ -517,6 +517,7 @@ curl -X POST https://$ROUTE_URL/api/admin/auth \
   -H "Content-Type: application/json" \
   -d '{"password":"IhrSicheresPasswort123!"}'
 ```
+Die Weboberfläche des Admin-Menüs erreichen Sie über das Zahnrad-Symbol oder unter `https://$ROUTE_URL/?admin=true`.
 
 ## 10. Scaling und Performance
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Die Anwendung läuft anschließend unter `http://localhost:5000`.
 
 ## Administration
 
+Der Admin-Bereich lässt sich über das Zahnrad-Symbol oben rechts oder direkt über den URL-Parameter `?admin=true` öffnen.
+
 ### Regeln importieren
 Beispiel einer JSON-Datei:
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -2,6 +2,8 @@
 
 Dieses Handbuch beschreibt die tägliche Nutzung der SmartRedirect Suite. Die Anwendung verwaltet mehr als 100.000 URL-Transformationsregeln und unterstützt Migrationen zwischen Domains.
 
+Den Admin-Bereich öffnen Sie über das Zahnrad-Symbol in der Kopfzeile oder indem Sie `?admin=true` an die URL anhängen.
+
 ## Allgemeine Einstellungen
 Nach der Anmeldung im Administrator-Bereich steht ein Menü mit vier Reitern zur Verfügung: **Allgemein**, **Regeln**, **Statistik** und **Import/Export**. Über die Schaltflächen im Kopfbereich können Sie sich abmelden oder den Admin-Bereich schließen.
 


### PR DESCRIPTION
## Summary
- explain how to open the admin menu via gear icon or `?admin=true`
- mention admin menu access in installation, user manual, and deployment guides
- record documentation update in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b22bea7c8331a3e04e37ad39b84e