### PR TITLE
feat: add closable persistent demo banner

### DIFF
--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -19,7 +19,7 @@ RUN npm ci --include=dev
 COPY . .
 
 RUN npm run build \
-    && printf '%s\n' '<div style="background:#fffbdd;padding:10px;text-align:center;">This is just a demo instance and will be reset every day.<br/>Admin password: <strong>Password1</strong>.<br/><a href="https://github.com/SmartRedirectSuite/SmartRedirectSuite" target="_blank" rel="noopener noreferrer">GitHub repository</a> - For any additional questions, please visit this page.</div>' > /tmp/banner.html \
+    && printf '%s\n' '<div id="demo-banner" style="background:#fffbdd;padding:10px;text-align:center;position:relative;">Dies ist nur eine Demo-Instanz und wird täglich zurückgesetzt. Admin-Passwort: <strong>Password1</strong>. <a href="https://github.com/SmartRedirectSuite/SmartRedirectSuite" target="_blank" rel="noopener noreferrer" style="color:#0645AD;font-weight:bold;text-decoration:underline;">GitHub-Repository</a> - Für weitere Fragen besuchen Sie diese Seite.<button id="banner-close" style="position:absolute;right:5px;top:5px;border:none;background:transparent;font-size:16px;cursor:pointer;">&times;</button></div><script>if(localStorage.getItem("demoBannerClosed")==="true"){document.getElementById("demo-banner").style.display="none";}document.getElementById("banner-close").addEventListener("click",function(){document.getElementById("demo-banner").style.display="none";localStorage.setItem("demoBannerClosed","true");});</script>' > /tmp/banner.html \
     && sed -i '/<body[^>]*>/r /tmp/banner.html' dist/public/index.html \
     && rm /tmp/banner.html
 


### PR DESCRIPTION
## Summary
- present a German demo notice with a more visible GitHub link
- allow closing the banner and remember it via localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b477b5508331b3c9da1db4860200