### PR TITLE
feat: add configurable popup modes

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -198,6 +198,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
     headerIcon: "ArrowRightLeft" as "ArrowLeftRight" | "ArrowRightLeft" | "AlertTriangle" | "XCircle" | "AlertCircle" | "Info" | "Bookmark" | "Share2" | "Clock" | "CheckCircle" | "Star" | "Heart" | "Bell" | "none",
     headerLogoUrl: "" as string | undefined,
     headerBackgroundColor: "#ffffff",
+    popupMode: "active" as "active" | "inline" | "disabled",
     mainTitle: "Veralteter Link erkannt",
     mainDescription: "Sie verwenden einen veralteten Link unserer Web-App. Bitte aktualisieren Sie Ihre Lesezeichen und verwenden Sie die neue URL unten.",
     mainBackgroundColor: "#ffffff",
@@ -454,7 +455,8 @@ export default function AdminPage({ onClose }: AdminPageProps) {
         headerIcon: settingsData.headerIcon || "ArrowRightLeft",
         headerLogoUrl: settingsData.headerLogoUrl || "",
         headerBackgroundColor: settingsData.headerBackgroundColor || "#ffffff",
-        mainTitle: settingsData.mainTitle || "", 
+        popupMode: settingsData.popupMode || "active",
+        mainTitle: settingsData.mainTitle || "",
         mainDescription: settingsData.mainDescription || "",
         mainBackgroundColor: settingsData.mainBackgroundColor || "#ffffff",
         alertIcon: settingsData.alertIcon || "AlertTriangle",
@@ -1674,7 +1676,25 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                           </div>
                         </div>
                         <div className="bg-gray-50/50 dark:bg-gray-800/30 rounded-lg p-4 sm:p-6 space-y-4 sm:space-y-6">
-                          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+                          <div>
+                            <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
+                              PopUp-Anzeige
+                            </label>
+                            <Select value={generalSettings.popupMode} onValueChange={(value) =>
+                              setGeneralSettings({ ...generalSettings, popupMode: value as any })
+                            }>
+                              <SelectTrigger className="bg-white dark:bg-gray-700">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="active">Aktiv</SelectItem>
+                                <SelectItem value="inline">Inline</SelectItem>
+                                <SelectItem value="disabled">Deaktiviert</SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className={`${generalSettings.popupMode === 'disabled' ? 'opacity-50 pointer-events-none' : ''} space-y-4 sm:space-y-6`}>
+                            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
                             <div>
                               <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
                                 Titel <span className="text-red-500">*</span>
@@ -1684,15 +1704,16 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                                 onChange={(e) => setGeneralSettings({ ...generalSettings, mainTitle: e.target.value })}
                                 placeholder="URL veraltet - Aktualisierung erforderlich"
                                 className={`bg-white dark:bg-gray-700 ${!generalSettings.mainTitle?.trim() ? 'border-red-500 focus:border-red-500' : ''}`}
+                                disabled={generalSettings.popupMode === 'disabled'}
                               />
                             </div>
                             <div>
                               <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
                                 Icon
                               </label>
-                              <Select value={generalSettings.alertIcon} onValueChange={(value) => 
+                              <Select value={generalSettings.alertIcon} onValueChange={(value) =>
                                 setGeneralSettings({ ...generalSettings, alertIcon: value as any })
-                              }>
+                              } disabled={generalSettings.popupMode === 'disabled'}>
                                 <SelectTrigger className="bg-white dark:bg-gray-700">
                                   <SelectValue />
                                 </SelectTrigger>
@@ -1715,6 +1736,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                               placeholder="Du verwendest einen alten Link. Dieser Link ist nicht mehr aktuell und wird bald nicht mehr funktionieren. Bitte verwende die neue URL und aktualisiere deine Verknüpfungen."
                               rows={3}
                               className={`bg-white dark:bg-gray-700 ${!generalSettings.mainDescription?.trim() ? 'border-red-500 focus:border-red-500' : ''}`}
+                              disabled={generalSettings.popupMode === 'disabled'}
                             />
                             <p className="text-xs text-gray-500 mt-1">
                               Erklärt dem Nutzer die Situation und warum die neue URL verwendet werden sollte
@@ -1729,6 +1751,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                               onChange={(e) => setGeneralSettings({ ...generalSettings, popupButtonText: e.target.value })}
                               placeholder="Zeige mir die neue URL"
                               className="bg-white dark:bg-gray-700"
+                              disabled={generalSettings.popupMode === 'disabled'}
                             />
                             <p className="text-xs text-gray-500 mt-1">
                               Text für den Button der das PopUp-Fenster öffnet
@@ -1739,9 +1762,9 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                               <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
                                 Alert-Hintergrundfarbe
                               </label>
-                              <Select value={generalSettings.alertBackgroundColor} onValueChange={(value) => 
+                              <Select value={generalSettings.alertBackgroundColor} onValueChange={(value) =>
                                 setGeneralSettings({ ...generalSettings, alertBackgroundColor: value as any })
-                              }>
+                              } disabled={generalSettings.popupMode === 'disabled'}>
                                 <SelectTrigger className="bg-white dark:bg-gray-700">
                                   <SelectValue />
                                 </SelectTrigger>
@@ -1764,12 +1787,14 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                                   value={generalSettings.mainBackgroundColor}
                                   onChange={(e) => setGeneralSettings({ ...generalSettings, mainBackgroundColor: e.target.value })}
                                   className="w-20 h-10 p-1 rounded-md border cursor-pointer"
+                                  disabled={generalSettings.popupMode === 'disabled'}
                                 />
                                 <Input
                                   value={generalSettings.mainBackgroundColor}
                                   onChange={(e) => setGeneralSettings({ ...generalSettings, mainBackgroundColor: e.target.value })}
                                   placeholder="#ffffff"
                                   className="flex-1 bg-white dark:bg-gray-700 font-mono text-sm"
+                                  disabled={generalSettings.popupMode === 'disabled'}
                                 />
                               </div>
                             </div>

--- a/client/src/pages/migration.tsx
+++ b/client/src/pages/migration.tsx
@@ -69,7 +69,7 @@ export default function MigrationPage({ onAdminAccess }: MigrationPageProps) {
   const [matchingRule, setMatchingRule] = useState<UrlRule | null>(null);
   const [infoText, setInfoText] = useState("");
   const [showPasswordModal, setShowPasswordModal] = useState(false);
-  const [showMainDialog, setShowMainDialog] = useState(true);
+  const [showMainDialog, setShowMainDialog] = useState(false);
   const [showUrlComparison, setShowUrlComparison] = useState(true);
   const [copySuccess, setCopySuccess] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -108,6 +108,12 @@ export default function MigrationPage({ onAdminAccess }: MigrationPageProps) {
   const { data: settings, isLoading: settingsLoading } = useQuery<GeneralSettings>({
     queryKey: ["/api/settings"],
   });
+
+  useEffect(() => {
+    if (settings) {
+      setShowMainDialog(settings.popupMode === 'active');
+    }
+  }, [settings]);
 
   useEffect(() => {
     const initializePage = async () => {
@@ -312,9 +318,18 @@ export default function MigrationPage({ onAdminAccess }: MigrationPageProps) {
 
           {!isLoading && (
             <div className="space-y-6">
-
-
-
+              {settings?.popupMode === 'inline' && (
+                <div className={`${getBackgroundColor(settings?.alertBackgroundColor || 'yellow')} rounded-lg p-4 flex items-start space-x-3`}>
+                  {(() => {
+                    const IconComponent = getIconComponent(settings?.alertIcon || 'AlertTriangle');
+                    return <IconComponent className="h-5 w-5 mt-0.5" />;
+                  })()}
+                  <div>
+                    <h3 className="font-semibold">{settings?.mainTitle || "Veralteter Link erkannt"}</h3>
+                    <p className="text-sm mt-1">{settings?.mainDescription || "Sie verwenden einen veralteten Link unserer Web-App. Bitte aktualisieren Sie Ihre Lesezeichen und verwenden Sie die neue URL unten."}</p>
+                  </div>
+                </div>
+              )}
 
               {/* URL Comparison Section - Shown on main page when requested */}
               {showUrlComparison && (
@@ -491,6 +506,7 @@ export default function MigrationPage({ onAdminAccess }: MigrationPageProps) {
       </footer>
 
       {/* Main Migration Dialog (Popup) */}
+      {settings?.popupMode === 'active' && (
       <Dialog open={showMainDialog} onOpenChange={setShowMainDialog}>
         <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto" style={{ backgroundColor: settings?.mainBackgroundColor || 'white' }}>
           <DialogHeader>
@@ -540,6 +556,7 @@ export default function MigrationPage({ onAdminAccess }: MigrationPageProps) {
           </div>
         </DialogContent>
       </Dialog>
+      )}
 
       <PasswordModal
         isOpen={showPasswordModal}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -660,7 +660,11 @@ export class FileStorage implements IStorage {
   async getGeneralSettings(): Promise<GeneralSettings> {
     try {
       const data = await fs.readFile(SETTINGS_FILE, 'utf-8');
-      return JSON.parse(data);
+      const settings = JSON.parse(data);
+      if (!settings.popupMode) {
+        settings.popupMode = 'active';
+      }
+      return settings;
     } catch {
       // Return default settings if file doesn't exist
       const defaultSettings: GeneralSettings = {
@@ -668,6 +672,7 @@ export class FileStorage implements IStorage {
         headerTitle: "URL Migration Tool",
         headerIcon: "ArrowRightLeft",
         headerBackgroundColor: "white",
+        popupMode: 'active',
         mainTitle: "Veralteter Link erkannt",
         mainDescription: "Sie verwenden einen veralteten Link unserer Web-App. Bitte aktualisieren Sie Ihre Lesezeichen und verwenden Sie die neue URL unten.",
         mainBackgroundColor: "white",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -22,6 +22,8 @@ export const COLOR_OPTIONS = [
   "yellow", "red", "orange", "blue", "gray", "white", "black"
 ] as const;
 
+export const POPUP_MODES = ["active", "inline", "disabled"] as const;
+
 export const REDIRECT_TYPES = ["wildcard", "partial"] as const;
 export const EXPORT_FORMATS = ["csv", "json"] as const;
 export const TIME_RANGES = ["24h", "7d", "all"] as const;
@@ -143,7 +145,10 @@ export const generalSettingsSchema = z.object({
   headerBackgroundColor: z.string()
     .regex(/^(#([0-9A-Fa-f]{3}){1,2}|[a-zA-Z]+)$/, "Invalid color format")
     .default("white"),
-    
+
+  // Popup display mode
+  popupMode: z.enum(POPUP_MODES).default('active'),
+
   // Main content section
   mainTitle: z.string()
     .min(1, "Haupttitel darf nicht leer sein")


### PR DESCRIPTION
## Summary
- allow choosing popup display mode (active, inline, disabled)
- disable popup fields in admin when popup disabled
- render inline message or hide popup on migration page based on settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899bf47d8fc8331bd308570d7652075