### PR TITLE
Fix unmatched div in admin settings form

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -1801,6 +1801,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                           </div>
                         </div>
                       </div>
+                      </div>
 
                       {/* 3. URL Comparison Settings */}
                       <div className="space-y-6">


### PR DESCRIPTION
## Summary
- close leftover `<div>` in admin settings form to restore valid JSX

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899cf5fdf0c8331bd2100611e151d6c