### PR TITLE
fix: align stats pagination counter on mobile

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -2870,7 +2870,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
 
                 {/* Search and pagination info for paginated views */}
                 {(statsView === 'top100' || statsView === 'browser') && (
-                  <div className="flex justify-between items-center text-sm text-muted-foreground mt-4">
+                  <div className="flex w-full sm:w-auto justify-between items-center text-sm text-muted-foreground mt-4 sm:mt-0">
                     <div>
                       {statsView === 'top100' && (
                         top100Loading ? (


### PR DESCRIPTION
## Summary
- ensure stats "Alle Einträge" pagination info spans full width on mobile so the page counter sits at the right edge
- remove unused regression test and update test script accordingly

## Testing
- `npm test`
- `npm audit` *(fails: 403 Forbidden - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1d15eb88331880412544c81c560