### PR TITLE
fix: match URL rules at any path depth

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -3,6 +3,7 @@
 > **Übersicht**: Diese API-Dokumentation beschreibt alle verfügbaren REST-Endpunkte für die URL-Migration-Anwendung. Für Installation siehe [INSTALLATION.md](./INSTALLATION.md), für vollständige Feature-Informationen [README.md](./README.md).
 
 ## 📚 Verwandte Dokumentation
+
 - **[README.md](./README.md)**: Vollständige Anwendungsdokumentation mit allen Features
 - **[INSTALLATION.md](./INSTALLATION.md)**: Schnellstart-Anleitung für Entwicklung
 - **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: Production-Deployment und Monitoring
@@ -14,6 +15,7 @@ The SmartRedirect Suite provides a comprehensive REST API for managing URL trans
 To open the web-based admin menu, use the gear icon in the application or append `?admin=true` to the base URL.
 
 ## Base URL
+
 ```
 Production: https://yourdomain.com/api
 Development: http://localhost:5000/api
@@ -24,6 +26,7 @@ Development: http://localhost:5000/api
 The API uses session-based authentication for admin operations. All admin endpoints require a valid session.
 
 ### Login
+
 ```http
 POST /api/admin/login
 Content-Type: application/json
@@ -34,6 +37,7 @@ Content-Type: application/json
 ```
 
 **Response**
+
 ```json
 {
   "success": true,
@@ -43,11 +47,13 @@ Content-Type: application/json
 ```
 
 ### Check Authentication Status
+
 ```http
 GET /api/admin/status
 ```
 
 **Response**
+
 ```json
 {
   "isAuthenticated": true,
@@ -57,11 +63,13 @@ GET /api/admin/status
 ```
 
 ### Logout
+
 ```http
 POST /api/admin/logout
 ```
 
 **Response**
+
 ```json
 {
   "success": true,
@@ -72,6 +80,7 @@ POST /api/admin/logout
 ## Public Endpoints
 
 ### Check URL Rules
+
 Checks if a path matches any configured transformation rules.
 
 ```http
@@ -84,6 +93,7 @@ Content-Type: application/json
 ```
 
 **Response**
+
 ```json
 {
   "hasMatch": true,
@@ -98,6 +108,7 @@ Content-Type: application/json
 ```
 
 ### Track URL Access
+
 Records URL access for analytics and migration tracking.
 
 ```http
@@ -114,6 +125,7 @@ Content-Type: application/json
 ```
 
 **Response**
+
 ```json
 {
   "success": true,
@@ -122,6 +134,7 @@ Content-Type: application/json
 ```
 
 ### Get General Settings
+
 Retrieves public configuration settings for the migration interface.
 
 ```http
@@ -129,6 +142,7 @@ GET /api/admin/settings
 ```
 
 **Response**
+
 ```json
 {
   "id": "settings_uuid",
@@ -152,11 +166,13 @@ All admin endpoints require authentication via session.
 ### URL Rules Management
 
 #### Get All Rules
+
 ```http
 GET /api/admin/rules
 ```
 
 **Response**
+
 ```json
 [
   {
@@ -171,6 +187,7 @@ GET /api/admin/rules
 ```
 
 #### Create Rule
+
 ```http
 POST /api/admin/rules
 Content-Type: application/json
@@ -184,12 +201,14 @@ Content-Type: application/json
 ```
 
 **Validation Requirements:**
-- `matcher`: Must start with `/` and be unique
+
+- `matcher`: Must start with `/`, be unique, and matches at any position in the path
 - `targetUrl`: Must be valid HTTP/HTTPS URL
 - `redirectType`: Either "wildcard" or "partial"
 - `infoText`: Optional, max 5000 characters
 
 **Response**
+
 ```json
 {
   "id": "new_rule_uuid",
@@ -202,6 +221,7 @@ Content-Type: application/json
 ```
 
 #### Update Rule
+
 ```http
 PUT /api/admin/rules/:id
 Content-Type: application/json
@@ -215,11 +235,13 @@ Content-Type: application/json
 ```
 
 #### Delete Rule
+
 ```http
 DELETE /api/admin/rules/:id
 ```
 
 **Response**
+
 ```json
 {
   "success": true,
@@ -228,6 +250,7 @@ DELETE /api/admin/rules/:id
 ```
 
 #### Bulk Delete Rules
+
 ```http
 DELETE /api/admin/bulk-delete-rules
 Content-Type: application/json
@@ -238,9 +261,11 @@ Content-Type: application/json
 ```
 
 **Validation Requirements:**
+
 - `ruleIds`: Array of valid rule UUIDs, minimum 1 item
 
 **Response**
+
 ```json
 {
   "success": true,
@@ -251,6 +276,7 @@ Content-Type: application/json
 ```
 
 **Error Response**
+
 ```json
 {
   "success": false,
@@ -259,6 +285,7 @@ Content-Type: application/json
 ```
 
 #### Import Rules
+
 ```http
 POST /api/admin/rules/import
 Content-Type: application/json
@@ -280,6 +307,7 @@ Content-Type: application/json
 ```
 
 **Response**
+
 ```json
 {
   "success": true,
@@ -292,11 +320,13 @@ Content-Type: application/json
 ### Statistics and Analytics
 
 #### Get Overview Statistics
+
 ```http
 GET /api/admin/stats/overview
 ```
 
 **Response**
+
 ```json
 {
   "stats": {
@@ -321,14 +351,17 @@ GET /api/admin/stats/overview
 ```
 
 #### Get Top 100 URLs
+
 ```http
 GET /api/admin/stats/top100
 ```
 
 **Query Parameters:**
+
 - `timeRange`: "24h", "7d", "30d", or "all"
 
 **Response**
+
 ```json
 [
   {
@@ -343,11 +376,13 @@ GET /api/admin/stats/top100
 ```
 
 #### Get All Entries
+
 ```http
 GET /api/admin/stats/entries
 ```
 
 **Query Parameters:**
+
 - `page`: Page number (default: 1)
 - `limit`: Items per page (default: 20, max: 100)
 - `sort`: Sort field (default: "timestamp")
@@ -355,6 +390,7 @@ GET /api/admin/stats/entries
 - `search`: Search term for filtering
 
 **Response**
+
 ```json
 {
   "data": [
@@ -381,6 +417,7 @@ GET /api/admin/stats/entries
 ### Settings Management
 
 #### Update Settings
+
 ```http
 PUT /api/admin/settings
 Content-Type: application/json
@@ -399,6 +436,7 @@ Content-Type: application/json
 ```
 
 **Validation Requirements:**
+
 - `headerTitle`: 1-100 characters
 - `mainTitle`: 1-200 characters
 - `mainDescription`: 1-1000 characters
@@ -408,6 +446,7 @@ Content-Type: application/json
 ### Logo Management
 
 #### Upload Logo
+
 ```http
 POST /api/admin/logo/upload
 Content-Type: application/json
@@ -419,6 +458,7 @@ Content-Type: application/json
 ```
 
 **Response**
+
 ```json
 {
   "uploadURL": "https://storage.googleapis.com/bucket/signed-upload-url",
@@ -427,6 +467,7 @@ Content-Type: application/json
 ```
 
 #### Set Logo
+
 ```http
 PUT /api/admin/logo
 Content-Type: application/json
@@ -437,6 +478,7 @@ Content-Type: application/json
 ```
 
 **Response**
+
 ```json
 {
   "success": true,
@@ -445,11 +487,13 @@ Content-Type: application/json
 ```
 
 #### Delete Logo
+
 ```http
 DELETE /api/admin/logo
 ```
 
 **Response**
+
 ```json
 {
   "success": true,
@@ -460,6 +504,7 @@ DELETE /api/admin/logo
 ### Data Export
 
 #### Export Data
+
 ```http
 POST /api/admin/export
 Content-Type: application/json
@@ -472,11 +517,13 @@ Content-Type: application/json
 ```
 
 **Parameters:**
+
 - `type`: "statistics", "rules", or "settings"
 - `format`: "csv" or "json"
 - `timeRange`: "24h", "7d", "30d", or "all" (for statistics only)
 
 **Response (CSV)**
+
 ```
 Content-Type: text/csv
 Content-Disposition: attachment; filename="url-statistics-20250106.csv"
@@ -486,6 +533,7 @@ Alte URL,Neue URL,Pfad,Zeitstempel,User-Agent,Referrer
 ```
 
 **Response (JSON)**
+
 ```json
 [
   {
@@ -521,15 +569,15 @@ All API endpoints return structured error responses:
 
 ### Error Codes
 
-| Code | Description |
-|------|-------------|
-| `VALIDATION_ERROR` | Request validation failed |
-| `AUTHENTICATION_REQUIRED` | Login required |
-| `UNAUTHORIZED` | Invalid credentials |
-| `NOT_FOUND` | Resource not found |
-| `CONFLICT` | Resource conflict (e.g., duplicate matcher) |
-| `RATE_LIMIT_EXCEEDED` | Too many requests |
-| `INTERNAL_ERROR` | Server error |
+| Code                      | Description                                 |
+| ------------------------- | ------------------------------------------- |
+| `VALIDATION_ERROR`        | Request validation failed                   |
+| `AUTHENTICATION_REQUIRED` | Login required                              |
+| `UNAUTHORIZED`            | Invalid credentials                         |
+| `NOT_FOUND`               | Resource not found                          |
+| `CONFLICT`                | Resource conflict (e.g., duplicate matcher) |
+| `RATE_LIMIT_EXCEEDED`     | Too many requests                           |
+| `INTERNAL_ERROR`          | Server error                                |
 
 ## Rate Limiting
 
@@ -539,6 +587,7 @@ The API implements rate limiting to prevent abuse:
 - **Auth Limit**: 5 authentication attempts per 15 minutes per IP
 
 Rate limit headers are included in responses:
+
 ```
 X-RateLimit-Limit: 100
 X-RateLimit-Remaining: 95
@@ -548,11 +597,13 @@ X-RateLimit-Reset: 2025-01-06T17:45:00.000Z
 ## Performance Monitoring
 
 ### Health Check
+
 ```http
 GET /api/health
 ```
 
 **Response**
+
 ```json
 {
   "status": "healthy",
@@ -573,6 +624,7 @@ GET /api/health
 ```
 
 ### Performance Metrics
+
 ```http
 GET /api/metrics
 ```
@@ -585,17 +637,17 @@ Real-time updates for admin interface:
 
 ```javascript
 // Connect to WebSocket
-const ws = new WebSocket('wss://yourdomain.com/ws');
+const ws = new WebSocket("wss://yourdomain.com/ws");
 
 // Listen for events
 ws.onmessage = (event) => {
   const data = JSON.parse(event.data);
-  
+
   switch (data.type) {
-    case 'url_accessed':
+    case "url_accessed":
       // Real-time URL access tracking
       break;
-    case 'settings_updated':
+    case "settings_updated":
       // Settings changed
       break;
   }
@@ -605,6 +657,7 @@ ws.onmessage = (event) => {
 ## SDK Examples
 
 ### JavaScript/Node.js
+
 ```javascript
 class URLMigrationAPI {
   constructor(baseURL, credentials) {
@@ -614,35 +667,35 @@ class URLMigrationAPI {
 
   async login() {
     const response = await fetch(`${this.baseURL}/admin/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ password: this.credentials.password }),
-      credentials: 'include'
+      credentials: "include",
     });
     return response.json();
   }
 
   async getRules() {
     const response = await fetch(`${this.baseURL}/admin/rules`, {
-      credentials: 'include'
+      credentials: "include",
     });
     return response.json();
   }
 
   async createRule(rule) {
     const response = await fetch(`${this.baseURL}/admin/rules`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(rule),
-      credentials: 'include'
+      credentials: "include",
     });
     return response.json();
   }
 }
 
 // Usage
-const api = new URLMigrationAPI('https://yourdomain.com/api', {
-  password: 'your_password'
+const api = new URLMigrationAPI("https://yourdomain.com/api", {
+  password: "your_password",
 });
 
 await api.login();
@@ -650,6 +703,7 @@ const rules = await api.getRules();
 ```
 
 ### Python
+
 ```python
 import requests
 
@@ -658,18 +712,18 @@ class URLMigrationAPI:
         self.base_url = base_url
         self.password = password
         self.session = requests.Session()
-    
+
     def login(self):
         response = self.session.post(
             f"{self.base_url}/admin/login",
             json={"password": self.password}
         )
         return response.json()
-    
+
     def get_rules(self):
         response = self.session.get(f"{self.base_url}/admin/rules")
         return response.json()
-    
+
     def create_rule(self, rule):
         response = self.session.post(
             f"{self.base_url}/admin/rules",
@@ -686,6 +740,7 @@ rules = api.get_rules()
 ## Testing
 
 ### API Testing with curl
+
 ```bash
 # Login
 curl -X POST http://localhost:5000/api/admin/login \
@@ -705,6 +760,7 @@ curl -X POST http://localhost:5000/api/admin/rules \
 ```
 
 ### Load Testing
+
 ```bash
 # Install artillery
 npm install -g artillery

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Diese Version basiert stets auf dem neuesten Commit des `main`-Branches, wird al
 ☕️ **Kaffee für den Code?** Wenn dir die SmartRedirect Suite gefällt, spendier mir auf [BuyMeACoffee](https://buymeacoffee.com/drunkenhusky) einen Kaffee und halte die Bits am Koffein!
 
 ## Inhaltsverzeichnis
+
 - [Key Features](#key-features)
 - [Dokumentation](#dokumentation)
 - [Impressions](#impressions)
@@ -34,6 +35,7 @@ Diese Version basiert stets auf dem neuesten Commit des `main`-Branches, wird al
 - [Änderungshistorie](#anderungshistorie)
 
 ## Key Features
+
 - Zentrale Regelverwaltung mit automatischer URL-Erkennung
 - Kontrollierte Migrationen und nachvollziehbare Domainwechsel
 - Produktivität: Multi-Select, Import/Export von Regeln
@@ -44,6 +46,7 @@ Diese Version basiert stets auf dem neuesten Commit des `main`-Branches, wird al
 - Responsives Design für Desktop und Mobilgeräte
 
 ## Dokumentation
+
 - [Benutzerhandbuch](./USER_MANUAL.md)
 - [Admin-Dokumentation](./ADMIN_DOCUMENTATION.md)
 - [Architektur-Übersicht](./ARCHITECTURE_OVERVIEW.md)
@@ -54,6 +57,7 @@ Diese Version basiert stets auf dem neuesten Commit des `main`-Branches, wird al
 Kurzer Überblick über zentrale Screens der SmartRedirect Suite.
 
 ### Website-Besucher
+
 1. **Initiale Meldung** – Hinweis, dass der verwendete Link veraltet ist und aktualisiert werden soll.  
    ![Initiale Meldung – Website Besucher](Impressions/Initiale%20Meldung%20Website%20Besucher.png)
 
@@ -61,6 +65,7 @@ Kurzer Überblick über zentrale Screens der SmartRedirect Suite.
    ![Anzeige neuer URL mit Hinweisen – Website Besucher nach Bestätigung Pop-up](Impressions/Anzeige%20neuer%20URL%20mit%20Hinweisen%20Website%20Besucher%20nach%20Best%C3%A4tigung%20Pop%20up.png)
 
 ### Admin-Bereich
+
 3. **Generelle Einstellungen** – Übersicht über globale Optionen und Grundkonfiguration.  
    ![Admin Menü – Generelle Einstellungen](Impressions/Admin%20Menu%20Generelle%20Einstellungen.png)
 
@@ -74,20 +79,27 @@ Kurzer Überblick über zentrale Screens der SmartRedirect Suite.
    ![Admin Menu – Import Export](Impressions/Admin%20Menu%20Import%20Export.png)
 
 ## Funktionsweise
+
 Jede Regel definiert:
+
 - einen **URL-Pfad-Matcher**
-- einen **Modus** (*Teilweise* oder *Vollständig*)
+- einen **Modus** (_Teilweise_ oder _Vollständig_)
 - Zielwerte (**Base-URL** oder **Ziel-URL**)
+
+Der Matcher greift an beliebiger Stelle im Pfad – eine Regel wie `/sites/team`
+matcht sowohl `/sites/team/docs` als auch `/archive/sites/team/docs`.
 
 **Fallback ohne Regeln:** Bei fehlenden Regeln erfolgt ein Domainersatz gemäß den allgemeinen Einstellungen; Pfad, Parameter und Anker bleiben erhalten.
 
 ### Regelmodi
-| Modus | Verhalten |
-|-------|-----------|
-| **Teilweise** | Ersetzt Pfadsegmente ab dem Matcher. Base‑URL stammt aus den allgemeinen Einstellungen; zusätzliche Segmente, Parameter und Anker werden angehängt. |
-| **Vollständig** | Leitet komplett auf eine neue Ziel‑URL um. Keine Bestandteile der alten URL werden übernommen. |
+
+| Modus           | Verhalten                                                                                                                                           |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Teilweise**   | Ersetzt Pfadsegmente ab dem Matcher. Base‑URL stammt aus den allgemeinen Einstellungen; zusätzliche Segmente, Parameter und Anker werden angehängt. |
+| **Vollständig** | Leitet komplett auf eine neue Ziel‑URL um. Keine Bestandteile der alten URL werden übernommen.                                                      |
 
 ### Beispiele
+
 **Ausgangs‑URL**
 
 ```
@@ -117,10 +129,11 @@ Ergebnis: https://neuesintranet.cloud.com/sites/team/docs/handbuch.pdf?version=3
 ```
 
 ### Regelpriorisierung (Spezifität)
+
 Die spezifischste Regel gewinnt. Der Spezifitäts‑Score \(S\) berechnet sich als:
 
 \[
-S = P_{path} \cdot WEIGHT\_PATH\_SEGMENT + P_{param} \cdot WEIGHT\_QUERY\_PAIR + W_{wildcards} \cdot PENALTY\_WILDCARD + E_{exact} \cdot BONUS\_EXACT\_MATCH
+S = P*{path} \cdot WEIGHT_PATH_SEGMENT + P*{param} \cdot WEIGHT_QUERY_PAIR + W*{wildcards} \cdot PENALTY_WILDCARD + E*{exact} \cdot BONUS_EXACT_MATCH
 \]
 
 - **P_path** – Anzahl exakt übereinstimmender statischer Pfadsegmente
@@ -136,6 +149,7 @@ Beispiele:
 Tie‑Breaker: mehr statische Segmente → mehr Query‑Paare → weniger Wildcards → älteres `createdAt`/niedrigere ID.
 
 ## Einsatzszenarien
+
 - Migrationen (z. B. SharePoint On‑Premises → SharePoint Online)
 - Domain‑Rebrands und Konsolidierungen
 - Umstrukturierungen großer Linklandschaften
@@ -143,6 +157,7 @@ Tie‑Breaker: mehr statische Segmente → mehr Query‑Paare → weniger Wildca
 ## Schnellstart
 
 ### Voraussetzungen
+
 - Node.js >= 22
 
 Überprüfen Sie die Installation:
@@ -166,6 +181,7 @@ npm install
 ```
 
 ### 3. .env-Datei erstellen
+
 Erstellen Sie eine `.env` Datei im Hauptverzeichnis:
 
 ```bash
@@ -207,6 +223,7 @@ Die Anwendung läuft anschließend unter `http://localhost:5000`.
 Der Admin-Bereich lässt sich über das Zahnrad-Symbol oben rechts oder direkt über den URL-Parameter `?admin=true` öffnen.
 
 ### Regeln importieren
+
 Beispiel einer JSON-Datei:
 
 ```json
@@ -225,7 +242,9 @@ Beispiel einer JSON-Datei:
 Im Admin-Panel hochladen oder über `sample-rules-import.json` einsehen.
 
 ### Einstellungen anpassen
+
 Im Admin-Panel können Texte, Farben und UI-Elemente angepasst werden, einschließlich:
+
 - Header und Icons
 - Popup-Texte
 - Labels im URL-Vergleich
@@ -233,14 +252,18 @@ Im Admin-Panel können Texte, Farben und UI-Elemente angepasst werden, einschlie
 - Zusätzliche Info-Bereiche
 
 ### Statistiken & Monitoring
+
 Das Admin-Panel zeigt:
+
 - Zugriffszahlen (gesamt, heute, Woche)
 - Top-URLs
 - Zeitbasierte Auswertungen (24h, 7 Tage, alle Daten)
 - Export als CSV/JSON
 
 ## Validierung & Qualitätssicherung
+
 Die Anwendung verhindert:
+
 - Doppelte URL-Matcher
 - Überlappende Regeln (z. B. `/news/` und `/news/archive/`)
 - Wildcard-Konflikte
@@ -249,11 +272,14 @@ Die Anwendung verhindert:
 Fehler werden detailliert auf Deutsch ausgegeben; bei Validierungsfehlern werden keine Änderungen gespeichert.
 
 ## Datenverwaltung
+
 Standardmäßig werden JSON-Dateien im `data/` Verzeichnis genutzt:
+
 - `data/rules.json`, `data/settings.json`, `data/tracking.json`
 - `data/sessions/` für Admin-Sessions
 
 ## Sicherheit
+
 - Persistente Session-Authentifizierung (7 Tage)
 - Sichere Cookies und dateibasierte Sessions
 - Passwortgeschützter Admin-Bereich
@@ -263,6 +289,7 @@ Standardmäßig werden JSON-Dateien im `data/` Verzeichnis genutzt:
 - Konfiguration über Umgebungsvariablen
 
 ## Deployment
+
 Lokale Produktion:
 
 ```bash
@@ -274,12 +301,15 @@ Weitere Plattformen: Vercel, Heroku oder Docker (Persistenz über `LOCAL_UPLOAD_
 Für Demo-Zwecke mit täglichem Reset der Daten kann das `Dockerfile.demo` genutzt werden (setzt Sessions, Uploads und Einstellungen täglich zurück).
 
 ## Entwicklung
+
 Technologie-Stack:
+
 - React 18, TypeScript, Vite, Tailwind CSS, shadcn/ui
 - Express.js und Zod im Backend
 - TanStack Query, Wouter, React Hook Form
 
 Richtlinien:
+
 1. TypeScript verwenden
 2. Zod-Schemas zur Validierung
 3. Shared Types zwischen Frontend und Backend
@@ -287,10 +317,11 @@ Richtlinien:
 5. Responsive, Mobile-First Design
 
 ## Support & Beitrag
+
 Bei Problemen:
+
 1. Konsolen-Logs prüfen
 2. Umgebungsvariablen kontrollieren
 3. Dependencies installieren
 4. `ADMIN_PASSWORD` verifizieren
 5. Upload-Pfad bei Logo-Fehlern prüfen
-

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,25 +1,32 @@
 import { randomUUID } from "crypto";
 import fs from "fs/promises";
 import path from "path";
-import type { 
-  UrlRule, 
-  InsertUrlRule, 
-  UrlTracking, 
+import type {
+  UrlRule,
+  InsertUrlRule,
+  UrlTracking,
   InsertUrlTracking,
   GeneralSettings,
   InsertGeneralSettings,
-  ImportUrlRule
+  ImportUrlRule,
 } from "@shared/schema";
+import { urlUtils } from "@shared/utils";
 
-const DATA_DIR = path.join(process.cwd(), 'data');
-const RULES_FILE = path.join(DATA_DIR, 'rules.json');
-const TRACKING_FILE = path.join(DATA_DIR, 'tracking.json');
-const SETTINGS_FILE = path.join(DATA_DIR, 'settings.json');
+const DATA_DIR = path.join(process.cwd(), "data");
+const RULES_FILE = path.join(DATA_DIR, "rules.json");
+const TRACKING_FILE = path.join(DATA_DIR, "tracking.json");
+const SETTINGS_FILE = path.join(DATA_DIR, "settings.json");
 
 export interface IStorage {
   // URL-Regeln
   getUrlRules(): Promise<UrlRule[]>;
-  getUrlRulesPaginated(page: number, limit: number, search?: string, sortBy?: string, sortOrder?: 'asc' | 'desc'): Promise<{
+  getUrlRulesPaginated(
+    page: number,
+    limit: number,
+    search?: string,
+    sortBy?: string,
+    sortOrder?: "asc" | "desc",
+  ): Promise<{
     rules: UrlRule[];
     total: number;
     totalPages: number;
@@ -28,42 +35,68 @@ export interface IStorage {
   }>;
   getUrlRule(id: string): Promise<UrlRule | undefined>;
   createUrlRule(rule: InsertUrlRule): Promise<UrlRule>;
-  updateUrlRule(id: string, rule: Partial<InsertUrlRule>): Promise<UrlRule | undefined>;
+  updateUrlRule(
+    id: string,
+    rule: Partial<InsertUrlRule>,
+  ): Promise<UrlRule | undefined>;
   deleteUrlRule(id: string): Promise<boolean>;
-  bulkDeleteUrlRules(ids: string[]): Promise<{deleted: number, notFound: number}>;
+  bulkDeleteUrlRules(
+    ids: string[],
+  ): Promise<{ deleted: number; notFound: number }>;
   clearAllRules(): Promise<void>;
-  
+
   // URL-Tracking
   trackUrlAccess(tracking: InsertUrlTracking): Promise<UrlTracking>;
-  getTrackingData(timeRange?: '24h' | '7d' | 'all'): Promise<UrlTracking[]>;
-  getTopUrls(limit?: number, timeRange?: '24h' | '7d' | 'all'): Promise<Array<{path: string, count: number}>>;
-  getTrackingStats(): Promise<{total: number, today: number, week: number}>;
+  getTrackingData(timeRange?: "24h" | "7d" | "all"): Promise<UrlTracking[]>;
+  getTopUrls(
+    limit?: number,
+    timeRange?: "24h" | "7d" | "all",
+  ): Promise<Array<{ path: string; count: number }>>;
+  getTrackingStats(): Promise<{ total: number; today: number; week: number }>;
 
   // Import functionality
-  importUrlRules(rules: ImportUrlRule[]): Promise<{imported: number, updated: number, errors: string[]}>;
-  
+  importUrlRules(
+    rules: ImportUrlRule[],
+  ): Promise<{ imported: number; updated: number; errors: string[] }>;
+
   // Enhanced statistics
   getAllTrackingEntries(): Promise<UrlTracking[]>;
-  searchTrackingEntries(query: string, sortBy?: string, sortOrder?: 'asc' | 'desc'): Promise<UrlTracking[]>;
-  
+  searchTrackingEntries(
+    query: string,
+    sortBy?: string,
+    sortOrder?: "asc" | "desc",
+  ): Promise<UrlTracking[]>;
+
   // Paginated statistics
-  getTrackingEntriesPaginated(page: number, limit: number, search?: string, sortBy?: string, sortOrder?: 'asc' | 'desc'): Promise<{
+  getTrackingEntriesPaginated(
+    page: number,
+    limit: number,
+    search?: string,
+    sortBy?: string,
+    sortOrder?: "asc" | "desc",
+  ): Promise<{
     entries: UrlTracking[];
     total: number;
     totalPages: number;
     currentPage: number;
     totalAllEntries: number;
   }>;
-  getTopUrlsPaginated(page: number, limit: number, timeRange?: '24h' | '7d' | 'all'): Promise<{
-    urls: Array<{path: string, count: number}>;
+  getTopUrlsPaginated(
+    page: number,
+    limit: number,
+    timeRange?: "24h" | "7d" | "all",
+  ): Promise<{
+    urls: Array<{ path: string; count: number }>;
     total: number;
     totalPages: number;
     currentPage: number;
   }>;
-  
+
   // General Settings
   getGeneralSettings(): Promise<GeneralSettings>;
-  updateGeneralSettings(settings: InsertGeneralSettings): Promise<GeneralSettings>;
+  updateGeneralSettings(
+    settings: InsertGeneralSettings,
+  ): Promise<GeneralSettings>;
 }
 
 export class FileStorage implements IStorage {
@@ -79,9 +112,12 @@ export class FileStorage implements IStorage {
     }
   }
 
-  private async readJsonFile<T>(filePath: string, defaultValue: T[]): Promise<T[]> {
+  private async readJsonFile<T>(
+    filePath: string,
+    defaultValue: T[],
+  ): Promise<T[]> {
     try {
-      const data = await fs.readFile(filePath, 'utf-8');
+      const data = await fs.readFile(filePath, "utf-8");
       return JSON.parse(data);
     } catch {
       return defaultValue;
@@ -98,11 +134,11 @@ export class FileStorage implements IStorage {
   }
 
   async getUrlRulesPaginated(
-    page: number = 1, 
-    limit: number = 50, 
-    search?: string, 
-    sortBy: string = 'createdAt', 
-    sortOrder: 'asc' | 'desc' = 'desc'
+    page: number = 1,
+    limit: number = 50,
+    search?: string,
+    sortBy: string = "createdAt",
+    sortOrder: "asc" | "desc" = "desc",
   ): Promise<{
     rules: UrlRule[];
     total: number;
@@ -112,89 +148,105 @@ export class FileStorage implements IStorage {
   }> {
     const allRules = await this.getUrlRules();
     const totalAllRules = allRules.length;
-    
+
     // Filter rules based on search
     let filteredRules = allRules;
     if (search && search.trim()) {
       const searchLower = search.toLowerCase();
-      filteredRules = allRules.filter(rule => 
-        rule.matcher.toLowerCase().includes(searchLower) ||
-        (rule.targetUrl && rule.targetUrl.toLowerCase().includes(searchLower)) ||
-        (rule.infoText && rule.infoText.toLowerCase().includes(searchLower))
+      filteredRules = allRules.filter(
+        (rule) =>
+          rule.matcher.toLowerCase().includes(searchLower) ||
+          (rule.targetUrl &&
+            rule.targetUrl.toLowerCase().includes(searchLower)) ||
+          (rule.infoText && rule.infoText.toLowerCase().includes(searchLower)),
       );
     }
-    
+
     // Sort rules
     filteredRules.sort((a, b) => {
       let comparison = 0;
-      
+
       switch (sortBy) {
-        case 'matcher':
+        case "matcher":
           comparison = a.matcher.localeCompare(b.matcher);
           break;
-        case 'targetUrl':
-          const aTarget = a.targetUrl || '';
-          const bTarget = b.targetUrl || '';
+        case "targetUrl":
+          const aTarget = a.targetUrl || "";
+          const bTarget = b.targetUrl || "";
           comparison = aTarget.localeCompare(bTarget);
           break;
-        case 'createdAt':
+        case "createdAt":
         default:
-          const aDate = new Date(a.createdAt || '').getTime();
-          const bDate = new Date(b.createdAt || '').getTime();
+          const aDate = new Date(a.createdAt || "").getTime();
+          const bDate = new Date(b.createdAt || "").getTime();
           comparison = aDate - bDate;
           break;
       }
-      
-      return sortOrder === 'asc' ? comparison : -comparison;
+
+      return sortOrder === "asc" ? comparison : -comparison;
     });
-    
+
     // Calculate pagination
     const total = filteredRules.length;
     const totalPages = Math.ceil(total / limit);
     const startIndex = (page - 1) * limit;
     const endIndex = startIndex + limit;
     const paginatedRules = filteredRules.slice(startIndex, endIndex);
-    
+
     return {
       rules: paginatedRules,
       total,
       totalPages,
       currentPage: page,
-      totalAllRules
+      totalAllRules,
     };
   }
 
   async getUrlRule(id: string): Promise<UrlRule | undefined> {
     const rules = await this.getUrlRules();
-    return rules.find(rule => rule.id === id);
+    return rules.find((rule) => rule.id === id);
   }
 
-  async createUrlRule(insertRule: InsertUrlRule, force: boolean = false): Promise<UrlRule> {
+  async createUrlRule(
+    insertRule: InsertUrlRule,
+    force: boolean = false,
+  ): Promise<UrlRule> {
     const rules = await this.getUrlRules();
-    
+
     // Skip validation if force flag is set
     if (!force) {
       // Validate for duplicates and overlaps
       const validationErrors: string[] = [];
-      
+
       // Check for exact duplicates
-      const existingRuleWithSameMatcher = rules.find(r => r.matcher === insertRule.matcher);
+      const existingRuleWithSameMatcher = rules.find(
+        (r) => r.matcher === insertRule.matcher,
+      );
       if (existingRuleWithSameMatcher) {
-        validationErrors.push(`URL-Matcher bereits vorhanden: "${insertRule.matcher}" (existierende Regel-ID: ${existingRuleWithSameMatcher.id})`);
+        validationErrors.push(
+          `URL-Matcher bereits vorhanden: "${insertRule.matcher}" (existierende Regel-ID: ${existingRuleWithSameMatcher.id})`,
+        );
       }
-      
+
       // Check for overlapping patterns
       for (const existingRule of rules) {
-        if (this.areMatchersOverlapping(insertRule.matcher, existingRule.matcher)) {
-          validationErrors.push(`Überlappender URL-Matcher: "${insertRule.matcher}" überschneidet sich mit "${existingRule.matcher}" (Regel-ID: ${existingRule.id})`);
+        if (
+          urlUtils.areMatchersOverlapping(
+            insertRule.matcher,
+            existingRule.matcher,
+          )
+        ) {
+          validationErrors.push(
+            `Überlappender URL-Matcher (Match an beliebiger Pfadposition): "${insertRule.matcher}" überschneidet sich mit "${existingRule.matcher}" (Regel-ID: ${existingRule.id})`,
+          );
         }
       }
-      
+
       if (validationErrors.length > 0) {
-        throw new Error(validationErrors.join('; '));
+        throw new Error(validationErrors.join("; "));
       }
     }
-    
+
     const rule: UrlRule = {
       ...insertRule,
       id: randomUUID(),
@@ -205,36 +257,49 @@ export class FileStorage implements IStorage {
     return rule;
   }
 
-  async updateUrlRule(id: string, updateData: Partial<InsertUrlRule>, force: boolean = false): Promise<UrlRule | undefined> {
+  async updateUrlRule(
+    id: string,
+    updateData: Partial<InsertUrlRule>,
+    force: boolean = false,
+  ): Promise<UrlRule | undefined> {
     const rules = await this.getUrlRules();
-    const index = rules.findIndex(rule => rule.id === id);
+    const index = rules.findIndex((rule) => rule.id === id);
     if (index === -1) return undefined;
-    
+
     // Skip validation if force flag is set or if matcher is not being updated
     if (!force && updateData.matcher) {
       const validationErrors: string[] = [];
-      
+
       // Check for exact duplicates (excluding the current rule being updated)
-      const existingRuleWithSameMatcher = rules.find(r => 
-        r.matcher === updateData.matcher && r.id !== id
+      const existingRuleWithSameMatcher = rules.find(
+        (r) => r.matcher === updateData.matcher && r.id !== id,
       );
       if (existingRuleWithSameMatcher) {
-        validationErrors.push(`URL-Matcher bereits vorhanden: "${updateData.matcher}" (existierende Regel-ID: ${existingRuleWithSameMatcher.id})`);
+        validationErrors.push(
+          `URL-Matcher bereits vorhanden: "${updateData.matcher}" (existierende Regel-ID: ${existingRuleWithSameMatcher.id})`,
+        );
       }
-      
+
       // Check for overlapping patterns (excluding the current rule being updated)
       for (const existingRule of rules) {
         if (existingRule.id === id) continue; // Skip current rule
-        if (this.areMatchersOverlapping(updateData.matcher, existingRule.matcher)) {
-          validationErrors.push(`Überlappender URL-Matcher: "${updateData.matcher}" überschneidet sich mit "${existingRule.matcher}" (Regel-ID: ${existingRule.id})`);
+        if (
+          urlUtils.areMatchersOverlapping(
+            updateData.matcher,
+            existingRule.matcher,
+          )
+        ) {
+          validationErrors.push(
+            `Überlappender URL-Matcher (Match an beliebiger Pfadposition): "${updateData.matcher}" überschneidet sich mit "${existingRule.matcher}" (Regel-ID: ${existingRule.id})`,
+          );
         }
       }
-      
+
       if (validationErrors.length > 0) {
-        throw new Error(validationErrors.join('; '));
+        throw new Error(validationErrors.join("; "));
       }
     }
-    
+
     rules[index] = { ...rules[index], ...updateData } as UrlRule;
     await this.writeJsonFile(RULES_FILE, rules);
     return rules[index];
@@ -242,29 +307,33 @@ export class FileStorage implements IStorage {
 
   async deleteUrlRule(id: string): Promise<boolean> {
     const rules = await this.getUrlRules();
-    const index = rules.findIndex(rule => rule.id === id);
+    const index = rules.findIndex((rule) => rule.id === id);
     if (index === -1) return false;
-    
+
     rules.splice(index, 1);
     await this.writeJsonFile(RULES_FILE, rules);
     return true;
   }
 
   // Atomic bulk delete to prevent race conditions
-  async bulkDeleteUrlRules(ids: string[]): Promise<{deleted: number, notFound: number}> {
+  async bulkDeleteUrlRules(
+    ids: string[],
+  ): Promise<{ deleted: number; notFound: number }> {
     const rules = await this.getUrlRules();
     const idsToDelete = new Set(ids);
-    
+
     const originalCount = rules.length;
-    const filteredRules = rules.filter(rule => !idsToDelete.has(rule.id));
+    const filteredRules = rules.filter((rule) => !idsToDelete.has(rule.id));
     const deletedCount = originalCount - filteredRules.length;
     const notFoundCount = ids.length - deletedCount;
-    
-    console.log(`ATOMIC BULK DELETE: Original ${originalCount}, Requested ${ids.length}, Deleted ${deletedCount}, Not found ${notFoundCount}`);
-    
+
+    console.log(
+      `ATOMIC BULK DELETE: Original ${originalCount}, Requested ${ids.length}, Deleted ${deletedCount}, Not found ${notFoundCount}`,
+    );
+
     // Single atomic write operation
     await this.writeJsonFile(RULES_FILE, filteredRules);
-    
+
     return { deleted: deletedCount, notFound: notFoundCount };
   }
 
@@ -273,16 +342,21 @@ export class FileStorage implements IStorage {
   }
 
   // URL-Tracking implementierung
-  async trackUrlAccess(insertTracking: InsertUrlTracking): Promise<UrlTracking> {
+  async trackUrlAccess(
+    insertTracking: InsertUrlTracking,
+  ): Promise<UrlTracking> {
     // Skip tracking for root path "/"
-    if (insertTracking.path === '/') {
+    if (insertTracking.path === "/") {
       return {
         ...insertTracking,
         id: randomUUID(),
       };
     }
-    
-    const trackingData = await this.readJsonFile<UrlTracking>(TRACKING_FILE, []);
+
+    const trackingData = await this.readJsonFile<UrlTracking>(
+      TRACKING_FILE,
+      [],
+    );
     const tracking: UrlTracking = {
       ...insertTracking,
       id: randomUUID(),
@@ -292,32 +366,40 @@ export class FileStorage implements IStorage {
     return tracking;
   }
 
-  async getTrackingData(timeRange?: '24h' | '7d' | 'all'): Promise<UrlTracking[]> {
-    const trackingData = await this.readJsonFile<UrlTracking>(TRACKING_FILE, []);
-    
-    if (!timeRange || timeRange === 'all') {
+  async getTrackingData(
+    timeRange?: "24h" | "7d" | "all",
+  ): Promise<UrlTracking[]> {
+    const trackingData = await this.readJsonFile<UrlTracking>(
+      TRACKING_FILE,
+      [],
+    );
+
+    if (!timeRange || timeRange === "all") {
       return trackingData;
     }
 
     const now = new Date();
     const cutoff = new Date();
-    
-    if (timeRange === '24h') {
+
+    if (timeRange === "24h") {
       cutoff.setHours(now.getHours() - 24);
-    } else if (timeRange === '7d') {
+    } else if (timeRange === "7d") {
       cutoff.setDate(now.getDate() - 7);
     }
 
-    return trackingData.filter(track => new Date(track.timestamp) >= cutoff);
+    return trackingData.filter((track) => new Date(track.timestamp) >= cutoff);
   }
 
-  async getTopUrls(limit = 10, timeRange?: '24h' | '7d' | 'all'): Promise<Array<{path: string, count: number}>> {
+  async getTopUrls(
+    limit = 10,
+    timeRange?: "24h" | "7d" | "all",
+  ): Promise<Array<{ path: string; count: number }>> {
     const trackingData = await this.getTrackingData(timeRange);
     const pathCounts = new Map<string, number>();
-    
+
     // Filter out root path "/" and admin access "/?admin=true" from statistics
-    trackingData.forEach(track => {
-      if (track.path !== '/' && track.path !== '/?admin=true') {
+    trackingData.forEach((track) => {
+      if (track.path !== "/" && track.path !== "/?admin=true") {
         const current = pathCounts.get(track.path) || 0;
         pathCounts.set(track.path, current + 1);
       }
@@ -329,88 +411,97 @@ export class FileStorage implements IStorage {
       .slice(0, limit);
   }
 
-
   // Enhanced statistics methods
   async getAllTrackingEntries(): Promise<UrlTracking[]> {
     return this.readJsonFile<UrlTracking>(TRACKING_FILE, []);
   }
 
-  async searchTrackingEntries(query: string, sortBy: string = 'timestamp', sortOrder: 'asc' | 'desc' = 'desc'): Promise<UrlTracking[]> {
+  async searchTrackingEntries(
+    query: string,
+    sortBy: string = "timestamp",
+    sortOrder: "asc" | "desc" = "desc",
+  ): Promise<UrlTracking[]> {
     const trackingData = await this.getAllTrackingEntries();
-    
+
     // Filter out root path "/" and then apply search query
-    let filteredData = trackingData.filter(entry => entry.path !== '/');
-    
+    let filteredData = trackingData.filter((entry) => entry.path !== "/");
+
     if (query.trim()) {
       const searchTerm = query.toLowerCase();
-      filteredData = filteredData.filter(entry =>
-        entry.oldUrl.toLowerCase().includes(searchTerm) ||
-        ((entry as any).newUrl && (entry as any).newUrl.toLowerCase().includes(searchTerm)) ||
-        entry.path.toLowerCase().includes(searchTerm) ||
-        entry.userAgent?.toLowerCase().includes(searchTerm)
+      filteredData = filteredData.filter(
+        (entry) =>
+          entry.oldUrl.toLowerCase().includes(searchTerm) ||
+          ((entry as any).newUrl &&
+            (entry as any).newUrl.toLowerCase().includes(searchTerm)) ||
+          entry.path.toLowerCase().includes(searchTerm) ||
+          entry.userAgent?.toLowerCase().includes(searchTerm),
       );
     }
-    
+
     // Sort data
     filteredData.sort((a, b) => {
       let aValue: any, bValue: any;
-      
+
       switch (sortBy) {
-        case 'timestamp':
+        case "timestamp":
           aValue = new Date(a.timestamp);
           bValue = new Date(b.timestamp);
           break;
-        case 'oldUrl':
+        case "oldUrl":
           aValue = a.oldUrl.toLowerCase();
           bValue = b.oldUrl.toLowerCase();
           break;
-        case 'newUrl':
-          aValue = ((a as any).newUrl || '').toLowerCase();
-          bValue = ((b as any).newUrl || '').toLowerCase();
+        case "newUrl":
+          aValue = ((a as any).newUrl || "").toLowerCase();
+          bValue = ((b as any).newUrl || "").toLowerCase();
           break;
-        case 'path':
+        case "path":
           aValue = a.path.toLowerCase();
           bValue = b.path.toLowerCase();
           break;
-        case 'userAgent':
-          aValue = (a.userAgent || '').toLowerCase();
-          bValue = (b.userAgent || '').toLowerCase();
+        case "userAgent":
+          aValue = (a.userAgent || "").toLowerCase();
+          bValue = (b.userAgent || "").toLowerCase();
           break;
         default:
           aValue = a.timestamp;
           bValue = b.timestamp;
       }
-      
-      if (sortOrder === 'asc') {
+
+      if (sortOrder === "asc") {
         return aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
       } else {
         return aValue > bValue ? -1 : aValue < bValue ? 1 : 0;
       }
     });
-    
+
     return filteredData;
   }
 
-  async getTrackingStats(): Promise<{total: number, today: number, week: number}> {
-    const all = await this.getTrackingData('all');
-    const today = await this.getTrackingData('24h');
-    const week = await this.getTrackingData('7d');
-    
+  async getTrackingStats(): Promise<{
+    total: number;
+    today: number;
+    week: number;
+  }> {
+    const all = await this.getTrackingData("all");
+    const today = await this.getTrackingData("24h");
+    const week = await this.getTrackingData("7d");
+
     // Filter out root path "/" from statistics
     return {
-      total: all.filter(track => track.path !== '/').length,
-      today: today.filter(track => track.path !== '/').length,
-      week: week.filter(track => track.path !== '/').length,
+      total: all.filter((track) => track.path !== "/").length,
+      today: today.filter((track) => track.path !== "/").length,
+      week: week.filter((track) => track.path !== "/").length,
     };
   }
 
   // Paginated statistics methods
   async getTrackingEntriesPaginated(
-    page: number = 1, 
-    limit: number = 50, 
-    search?: string, 
-    sortBy: string = 'timestamp', 
-    sortOrder: 'asc' | 'desc' = 'desc'
+    page: number = 1,
+    limit: number = 50,
+    search?: string,
+    sortBy: string = "timestamp",
+    sortOrder: "asc" | "desc" = "desc",
   ): Promise<{
     entries: UrlTracking[];
     total: number;
@@ -420,31 +511,32 @@ export class FileStorage implements IStorage {
   }> {
     const allEntries = await this.getAllTrackingEntries();
     const totalAllEntries = allEntries.length;
-    
+
     // Filter entries based on search
-    let filteredEntries = search && search.trim() 
-      ? await this.searchTrackingEntries(search, sortBy, sortOrder)
-      : allEntries.filter(entry => entry.path !== '/'); // Filter root path
-    
+    let filteredEntries =
+      search && search.trim()
+        ? await this.searchTrackingEntries(search, sortBy, sortOrder)
+        : allEntries.filter((entry) => entry.path !== "/"); // Filter root path
+
     if (!search || !search.trim()) {
       // Only sort if not already sorted by searchTrackingEntries
       filteredEntries.sort((a, b) => {
         let aValue: any, bValue: any;
-        
+
         switch (sortBy) {
-          case 'timestamp':
+          case "timestamp":
             aValue = new Date(a.timestamp);
             bValue = new Date(b.timestamp);
             break;
-          case 'oldUrl':
+          case "oldUrl":
             aValue = a.oldUrl.toLowerCase();
             bValue = b.oldUrl.toLowerCase();
             break;
-          case 'newUrl':
-            aValue = ((a as any).newUrl || '').toLowerCase();
-            bValue = ((b as any).newUrl || '').toLowerCase();
+          case "newUrl":
+            aValue = ((a as any).newUrl || "").toLowerCase();
+            bValue = ((b as any).newUrl || "").toLowerCase();
             break;
-          case 'path':
+          case "path":
             aValue = a.path.toLowerCase();
             bValue = b.path.toLowerCase();
             break;
@@ -452,60 +544,62 @@ export class FileStorage implements IStorage {
             aValue = a.timestamp;
             bValue = b.timestamp;
         }
-        
-        if (sortOrder === 'asc') {
+
+        if (sortOrder === "asc") {
           return aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
         } else {
           return aValue > bValue ? -1 : aValue < bValue ? 1 : 0;
         }
       });
     }
-    
+
     // Calculate pagination
     const total = filteredEntries.length;
     const totalPages = Math.ceil(total / limit);
     const startIndex = (page - 1) * limit;
     const endIndex = startIndex + limit;
     const paginatedEntries = filteredEntries.slice(startIndex, endIndex);
-    
+
     return {
       entries: paginatedEntries,
       total,
       totalPages,
       currentPage: page,
-      totalAllEntries
+      totalAllEntries,
     };
   }
 
   async getTopUrlsPaginated(
-    page: number = 1, 
-    limit: number = 50, 
-    timeRange?: '24h' | '7d' | 'all'
+    page: number = 1,
+    limit: number = 50,
+    timeRange?: "24h" | "7d" | "all",
   ): Promise<{
-    urls: Array<{path: string, count: number}>;
+    urls: Array<{ path: string; count: number }>;
     total: number;
     totalPages: number;
     currentPage: number;
   }> {
     const allUrls = await this.getTopUrls(10000, timeRange); // Get a large number first
-    
+
     // Calculate pagination
     const total = allUrls.length;
     const totalPages = Math.ceil(total / limit);
     const startIndex = (page - 1) * limit;
     const endIndex = startIndex + limit;
     const paginatedUrls = allUrls.slice(startIndex, endIndex);
-    
+
     return {
       urls: paginatedUrls,
       total,
       totalPages,
-      currentPage: page
+      currentPage: page,
     };
   }
 
   // Import functionality implementierung
-  async importUrlRules(importRules: any[]): Promise<{imported: number, updated: number, errors: string[]}> {
+  async importUrlRules(
+    importRules: any[],
+  ): Promise<{ imported: number; updated: number; errors: string[] }> {
     const existingRules = await this.getUrlRules();
     let imported = 0;
     let updated = 0;
@@ -523,14 +617,19 @@ export class FileStorage implements IStorage {
         id: rawRule.id,
         matcher: rawRule.matcher,
         targetUrl: rawRule.targetUrl,
-        redirectType: rawRule.redirectType || (rawRule.type === "redirect" ? "partial" : rawRule.type) || "partial", // Handle both field names
+        redirectType:
+          rawRule.redirectType ||
+          (rawRule.type === "redirect" ? "partial" : rawRule.type) ||
+          "partial", // Handle both field names
         infoText: rawRule.infoText || "",
         autoRedirect: rawRule.autoRedirect ?? false,
       };
 
       if (importRule.id) {
         // If ID is provided, check if rule exists and update it
-        const existingRuleIndex = existingRules.findIndex(r => r.id === importRule.id);
+        const existingRuleIndex = existingRules.findIndex(
+          (r) => r.id === importRule.id,
+        );
         if (existingRuleIndex !== -1) {
           const existingRule = existingRules[existingRuleIndex]!;
           const updatedRule: UrlRule = {
@@ -559,7 +658,9 @@ export class FileStorage implements IStorage {
         }
       } else {
         // No ID provided, check for duplicate matcher first
-        const duplicateIndex = existingRules.findIndex(r => r.matcher === importRule.matcher);
+        const duplicateIndex = existingRules.findIndex(
+          (r) => r.matcher === importRule.matcher,
+        );
         if (duplicateIndex !== -1) {
           const existingRule = existingRules[duplicateIndex]!;
           const updatedRule: UrlRule = {
@@ -595,74 +696,15 @@ export class FileStorage implements IStorage {
 
     return { imported, updated, errors: [] };
   }
-  
-  // Helper method to check if two URL matchers are overlapping
-  private areMatchersOverlapping(matcher1: string, matcher2: string): boolean {
-    // Remove leading/trailing slashes for comparison
-    const clean1 = matcher1.replace(/^\/+|\/+$/g, '');
-    const clean2 = matcher2.replace(/^\/+|\/+$/g, '');
-    
-    // Exact match
-    if (clean1 === clean2) return true;
-    
-    // For URL paths, we need to be precise about what constitutes an overlap
-    // "/news/" and "/news-beitrag/" are NOT overlapping - they're different paths
-    // Only consider overlap if one path is a TRUE prefix of another with proper path separation
-    
-    const segments1 = clean1.split('/').filter(s => s.length > 0);
-    const segments2 = clean2.split('/').filter(s => s.length > 0);
-    
-    // Check if one is a true path prefix of the other
-    const isPrefix = (shorter: string[], longer: string[]) => {
-      if (shorter.length >= longer.length) return false;
-      return shorter.every((segment, i) => segment === longer[i]);
-    };
-    
-    // Examples of TRUE overlaps:
-    // "/news/" and "/news/archive/" (prefix relationship)
-    // "/api/" and "/api/v1/" (prefix relationship)
-    // 
-    // Examples of NO overlap:
-    // "/news/" and "/news-beitrag/" (different segments: "news" vs "news-beitrag")
-    // "/api/" and "/apikey/" (different segments: "api" vs "apikey")
-    if (segments1.length < segments2.length && isPrefix(segments1, segments2)) {
-      return true;
-    }
-    if (segments2.length < segments1.length && isPrefix(segments2, segments1)) {
-      return true;
-    }
-    
-    // Check for wildcard overlaps (if using patterns like /news*)
-    if (matcher1.includes('*') || matcher2.includes('*')) {
-      const pattern1 = matcher1.replace(/\*/g, '.*');
-      const pattern2 = matcher2.replace(/\*/g, '.*');
-      
-      try {
-        const regex1 = new RegExp(`^${pattern1}$`);
-        const regex2 = new RegExp(`^${pattern2}$`);
-        
-        // Test if patterns would match each other's base strings
-        const base1 = matcher1.replace(/\*/g, '');
-        const base2 = matcher2.replace(/\*/g, '');
-        
-        if (regex1.test(base2) || regex2.test(base1)) {
-          return true;
-        }
-      } catch (e) {
-        // Invalid regex, skip this check
-      }
-    }
-    
-    return false;
-  }
 
+  // Helper method to check if two URL matchers are overlapping
   // General Settings implementierung
   async getGeneralSettings(): Promise<GeneralSettings> {
     try {
-      const data = await fs.readFile(SETTINGS_FILE, 'utf-8');
+      const data = await fs.readFile(SETTINGS_FILE, "utf-8");
       const settings = JSON.parse(data);
       if (!settings.popupMode) {
-        settings.popupMode = 'active';
+        settings.popupMode = "active";
       }
       return settings;
     } catch {
@@ -672,9 +714,10 @@ export class FileStorage implements IStorage {
         headerTitle: "URL Migration Tool",
         headerIcon: "ArrowRightLeft",
         headerBackgroundColor: "white",
-        popupMode: 'active',
+        popupMode: "active",
         mainTitle: "Veralteter Link erkannt",
-        mainDescription: "Sie verwenden einen veralteten Link unserer Web-App. Bitte aktualisieren Sie Ihre Lesezeichen und verwenden Sie die neue URL unten.",
+        mainDescription:
+          "Sie verwenden einen veralteten Link unserer Web-App. Bitte aktualisieren Sie Ihre Lesezeichen und verwenden Sie die neue URL unten.",
         mainBackgroundColor: "white",
         alertIcon: "AlertTriangle",
         alertBackgroundColor: "yellow",
@@ -689,29 +732,37 @@ export class FileStorage implements IStorage {
         showUrlButtonText: "Zeige mir die neue URL",
         popupButtonText: "Zeige mir die neue URL",
         specialHintsTitle: "Spezielle Hinweise für diese URL",
-        specialHintsDescription: "Hier finden Sie spezifische Informationen und Hinweise für die Migration dieser URL.",
+        specialHintsDescription:
+          "Hier finden Sie spezifische Informationen und Hinweise für die Migration dieser URL.",
         specialHintsIcon: "Info",
         infoTitle: "Zusätzliche Informationen",
         infoTitleIcon: "Info",
         infoItems: ["", "", ""],
         infoIcons: ["Bookmark", "Share2", "Clock"],
-        footerCopyright: "© 2024 URL Migration Service. Alle Rechte vorbehalten.",
+        footerCopyright:
+          "© 2024 URL Migration Service. Alle Rechte vorbehalten.",
         updatedAt: new Date().toISOString(),
         autoRedirect: false,
       };
-      
+
       // Save default settings directly to avoid infinite loop
-      await fs.writeFile(SETTINGS_FILE, JSON.stringify(defaultSettings, null, 2));
+      await fs.writeFile(
+        SETTINGS_FILE,
+        JSON.stringify(defaultSettings, null, 2),
+      );
       return defaultSettings;
     }
   }
 
-  async updateGeneralSettings(insertSettings: InsertGeneralSettings, replaceMode: boolean = false): Promise<GeneralSettings> {
+  async updateGeneralSettings(
+    insertSettings: InsertGeneralSettings,
+    replaceMode: boolean = false,
+  ): Promise<GeneralSettings> {
     // Get existing settings to preserve ID and any fields not being updated
     const existingSettings = await this.getGeneralSettings();
-    
+
     let settings: GeneralSettings;
-    
+
     if (replaceMode) {
       // In replace mode, use only the provided settings plus required fields
       settings = {
@@ -727,15 +778,18 @@ export class FileStorage implements IStorage {
         id: existingSettings.id, // Keep the existing ID
         updatedAt: new Date().toISOString(),
       };
-      
+
       // Remove any undefined or null properties when explicitly set to null
-      Object.keys(settings).forEach(key => {
-        if (insertSettings.hasOwnProperty(key) && (insertSettings as any)[key] === null) {
+      Object.keys(settings).forEach((key) => {
+        if (
+          insertSettings.hasOwnProperty(key) &&
+          (insertSettings as any)[key] === null
+        ) {
           delete (settings as any)[key];
         }
       });
     }
-    
+
     await fs.writeFile(SETTINGS_FILE, JSON.stringify(settings, null, 2));
     return settings;
   }

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -28,7 +28,7 @@ export const urlUtils = {
     try {
       const urlObj = new URL(url);
       // Remove trailing slash, normalize case
-      const normalized = `${urlObj.protocol}//${urlObj.host.toLowerCase()}${urlObj.pathname.replace(/\/$/, '')}${urlObj.search}${urlObj.hash}`;
+      const normalized = `${urlObj.protocol}//${urlObj.host.toLowerCase()}${urlObj.pathname.replace(/\/$/, "")}${urlObj.search}${urlObj.hash}`;
       return normalized;
     } catch {
       return url;
@@ -55,25 +55,43 @@ export const urlUtils = {
   },
 
   /**
-   * Checks if two URL matchers overlap
+   * Checks if two URL matchers overlap. A matcher can appear at any position
+   * within a path, therefore we test if their segment patterns can align at
+   * any offset.
    */
   areMatchersOverlapping(matcher1: string, matcher2: string): boolean {
-    const normalize = (m: string) => m.toLowerCase().replace(/\/+$/, '');
+    const normalize = (m: string) =>
+      m.toLowerCase().split("?")[0].replace(/\/+$/, "");
     const m1 = normalize(matcher1);
     const m2 = normalize(matcher2);
-    
-    if (m1 === m2) return true;
-    
-    const segments1 = m1.split('/').filter(Boolean);
-    const segments2 = m2.split('/').filter(Boolean);
-    
-    const minLength = Math.min(segments1.length, segments2.length);
-    
-    for (let i = 0; i < minLength; i++) {
-      if (segments1[i] !== segments2[i]) return false;
+
+    const segs1 = m1.split("/").filter(Boolean);
+    const segs2 = m2.split("/").filter(Boolean);
+    const len1 = segs1.length;
+    const len2 = segs2.length;
+
+    const segmentsCompatible = (a: string, b: string) => {
+      if (a === b) return true;
+      if (a === "*" || a.startsWith(":")) return true;
+      if (b === "*" || b.startsWith(":")) return true;
+      return false;
+    };
+
+    for (let offset = -(len1 - 1); offset <= len2 - 1; offset++) {
+      let overlap = false;
+      let ok = true;
+      for (let i = 0; i < len1; i++) {
+        const j = i + offset;
+        if (j < 0 || j >= len2) continue;
+        overlap = true;
+        if (!segmentsCompatible(segs1[i], segs2[j])) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok && overlap) return true;
     }
-    
-    return segments1.length !== segments2.length;
+    return false;
   },
 };
 
@@ -84,7 +102,7 @@ export const stringUtils = {
   /**
    * Safely truncates text with ellipsis
    */
-  truncate(text: string, maxLength: number, suffix = '...'): string {
+  truncate(text: string, maxLength: number, suffix = "..."): string {
     if (text.length <= maxLength) return text;
     return text.slice(0, maxLength - suffix.length) + suffix;
   },
@@ -93,7 +111,7 @@ export const stringUtils = {
    * Escapes HTML to prevent XSS
    */
   escapeHtml(text: string): string {
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     div.textContent = text;
     return div.innerHTML;
   },
@@ -102,8 +120,9 @@ export const stringUtils = {
    * Generates a random string with specified length
    */
   generateRandomString(length: number): string {
-    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    let result = '';
+    const chars =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let result = "";
     for (let i = 0; i < length; i++) {
       result += chars.charAt(Math.floor(Math.random() * chars.length));
     }
@@ -121,8 +140,9 @@ export const stringUtils = {
    * Capitalizes first letter of each word
    */
   toTitleCase(text: string): string {
-    return text.replace(/\w\S*/g, (txt) => 
-      txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+    return text.replace(
+      /\w\S*/g,
+      (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase(),
     );
   },
 };
@@ -134,15 +154,18 @@ export const dateUtils = {
   /**
    * Formats date for consistent display
    */
-  formatDate(date: string | Date, format: 'short' | 'long' | 'iso' = 'short'): string {
+  formatDate(
+    date: string | Date,
+    format: "short" | "long" | "iso" = "short",
+  ): string {
     const d = new Date(date);
-    
+
     switch (format) {
-      case 'short':
+      case "short":
         return d.toLocaleDateString();
-      case 'long':
+      case "long":
         return d.toLocaleString();
-      case 'iso':
+      case "iso":
         return d.toISOString();
       default:
         return d.toString();
@@ -156,32 +179,32 @@ export const dateUtils = {
     const now = new Date();
     const target = new Date(date);
     const diffMs = now.getTime() - target.getTime();
-    
+
     const seconds = Math.floor(diffMs / 1000);
     const minutes = Math.floor(seconds / 60);
     const hours = Math.floor(minutes / 60);
     const days = Math.floor(hours / 24);
-    
-    if (days > 0) return `${days} day${days > 1 ? 's' : ''} ago`;
-    if (hours > 0) return `${hours} hour${hours > 1 ? 's' : ''} ago`;
-    if (minutes > 0) return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
-    return 'Just now';
+
+    if (days > 0) return `${days} day${days > 1 ? "s" : ""} ago`;
+    if (hours > 0) return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+    if (minutes > 0) return `${minutes} minute${minutes > 1 ? "s" : ""} ago`;
+    return "Just now";
   },
 
   /**
    * Checks if date is within specified range
    */
-  isWithinRange(date: string | Date, range: '24h' | '7d' | '30d'): boolean {
+  isWithinRange(date: string | Date, range: "24h" | "7d" | "30d"): boolean {
     const now = new Date();
     const target = new Date(date);
     const diffMs = now.getTime() - target.getTime();
-    
+
     switch (range) {
-      case '24h':
+      case "24h":
         return diffMs <= 24 * 60 * 60 * 1000;
-      case '7d':
+      case "7d":
         return diffMs <= 7 * 24 * 60 * 60 * 1000;
-      case '30d':
+      case "30d":
         return diffMs <= 30 * 24 * 60 * 60 * 1000;
       default:
         return false;
@@ -198,7 +221,7 @@ export const performanceUtils = {
    */
   debounce<T extends (...args: unknown[]) => unknown>(
     func: T,
-    wait: number
+    wait: number,
   ): (...args: Parameters<T>) => void {
     let timeout: NodeJS.Timeout;
     return (...args: Parameters<T>) => {
@@ -212,7 +235,7 @@ export const performanceUtils = {
    */
   throttle<T extends (...args: unknown[]) => unknown>(
     func: T,
-    limit: number
+    limit: number,
   ): (...args: Parameters<T>) => void {
     let inThrottle: boolean;
     return (...args: Parameters<T>) => {
@@ -270,19 +293,19 @@ export const validationUtils = {
     let score = 0;
 
     if (password.length >= 8) score += 1;
-    else feedback.push('Password must be at least 8 characters long');
+    else feedback.push("Password must be at least 8 characters long");
 
     if (/[a-z]/.test(password)) score += 1;
-    else feedback.push('Password must contain lowercase letters');
+    else feedback.push("Password must contain lowercase letters");
 
     if (/[A-Z]/.test(password)) score += 1;
-    else feedback.push('Password must contain uppercase letters');
+    else feedback.push("Password must contain uppercase letters");
 
     if (/\d/.test(password)) score += 1;
-    else feedback.push('Password must contain numbers');
+    else feedback.push("Password must contain numbers");
 
     if (/[^a-zA-Z\d]/.test(password)) score += 1;
-    else feedback.push('Password should contain special characters');
+    else feedback.push("Password should contain special characters");
 
     return {
       isValid: score >= 3,
@@ -294,7 +317,11 @@ export const validationUtils = {
   /**
    * Validates file size and type
    */
-  validateFile(file: File, allowedTypes: string[], maxSize: number): {
+  validateFile(
+    file: File,
+    allowedTypes: string[],
+    maxSize: number,
+  ): {
     isValid: boolean;
     errors: string[];
   } {
@@ -324,8 +351,8 @@ export const errorUtils = {
    */
   getErrorMessage(error: unknown): string {
     if (error instanceof Error) return error.message;
-    if (typeof error === 'string') return error;
-    return 'An unknown error occurred';
+    if (typeof error === "string") return error;
+    return "An unknown error occurred";
   },
 
   /**
@@ -346,10 +373,10 @@ export const errorUtils = {
    */
   logError(error: unknown, context?: Record<string, unknown>): void {
     const message = this.getErrorMessage(error);
-    console.error('Error:', message, context);
-    
+    console.error("Error:", message, context);
+
     // In production, send to error tracking service
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV === "production") {
       // Example: Sentry.captureException(error, { extra: context });
     }
   },
@@ -363,7 +390,7 @@ export const formatUtils = {
    * Formats file size in human-readable format
    */
   formatFileSize(bytes: number): string {
-    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const units = ["B", "KB", "MB", "GB", "TB"];
     let size = bytes;
     let unitIndex = 0;
 
@@ -378,7 +405,7 @@ export const formatUtils = {
   /**
    * Formats number with locale-specific formatting
    */
-  formatNumber(num: number, locale = 'en-US'): string {
+  formatNumber(num: number, locale = "en-US"): string {
     return new Intl.NumberFormat(locale).format(num);
   },
 
@@ -386,7 +413,7 @@ export const formatUtils = {
    * Formats percentage
    */
   formatPercentage(value: number, total: number): string {
-    if (total === 0) return '0%';
+    if (total === 0) return "0%";
     const percentage = (value / total) * 100;
     return `${percentage.toFixed(1)}%`;
   },

--- a/test-rule-specificity.ts
+++ b/test-rule-specificity.ts
@@ -1,15 +1,15 @@
-import assert from 'node:assert/strict';
-import { selectMostSpecificRule } from './shared/ruleMatching';
-import { RULE_MATCHING_CONFIG } from './shared/constants';
-import type { UrlRule } from './shared/schema';
+import assert from "node:assert/strict";
+import { selectMostSpecificRule } from "./shared/ruleMatching";
+import { RULE_MATCHING_CONFIG } from "./shared/constants";
+import type { UrlRule } from "./shared/schema";
 
 function makeRule(id: string, matcher: string, createdOffset = 0): UrlRule {
   return {
     id,
     matcher,
-    targetUrl: '',
-    redirectType: 'partial',
-    infoText: '',
+    targetUrl: "",
+    redirectType: "partial",
+    infoText: "",
     autoRedirect: false,
     createdAt: new Date(2020, 0, 1 + createdOffset).toISOString(),
   };
@@ -17,58 +17,76 @@ function makeRule(id: string, matcher: string, createdOffset = 0): UrlRule {
 
 // Basis: /subsite vs /subsite/xyz
 {
-  const rules = [makeRule('1', '/subsite'), makeRule('2', '/subsite/xyz')];
-  const r = selectMostSpecificRule('/subsite/xyz', rules, RULE_MATCHING_CONFIG);
-  assert.equal(r?.matcher, '/subsite/xyz');
+  const rules = [makeRule("1", "/subsite"), makeRule("2", "/subsite/xyz")];
+  const r = selectMostSpecificRule("/subsite/xyz", rules, RULE_MATCHING_CONFIG);
+  assert.equal(r?.matcher, "/subsite/xyz");
+}
+
+// Matcher appearing deeper in path
+{
+  const rules = [makeRule("1", "/deep/path"), makeRule("2", "/other")];
+  const r = selectMostSpecificRule(
+    "/prefix/deep/path/suffix",
+    rules,
+    RULE_MATCHING_CONFIG,
+  );
+  assert.equal(r?.matcher, "/deep/path");
 }
 
 // Basis: query match
 {
-  const rules = [makeRule('1', '/subsite'), makeRule('2', '/subsite?document.aspx=123')];
-  const r = selectMostSpecificRule('/subsite?document.aspx=123', rules, RULE_MATCHING_CONFIG);
-  assert.equal(r?.matcher, '/subsite?document.aspx=123');
+  const rules = [
+    makeRule("1", "/subsite"),
+    makeRule("2", "/subsite?document.aspx=123"),
+  ];
+  const r = selectMostSpecificRule(
+    "/subsite?document.aspx=123",
+    rules,
+    RULE_MATCHING_CONFIG,
+  );
+  assert.equal(r?.matcher, "/subsite?document.aspx=123");
 }
 
 // Query dominance same path
 {
-  const rules = [makeRule('1', '/a/b'), makeRule('2', '/a/b?x=1')];
-  const r = selectMostSpecificRule('/a/b?x=1', rules, RULE_MATCHING_CONFIG);
-  assert.equal(r?.matcher, '/a/b?x=1');
+  const rules = [makeRule("1", "/a/b"), makeRule("2", "/a/b?x=1")];
+  const r = selectMostSpecificRule("/a/b?x=1", rules, RULE_MATCHING_CONFIG);
+  assert.equal(r?.matcher, "/a/b?x=1");
 }
 
 // Wildcard vs static
 {
-  const rules = [makeRule('1', '/a/*'), makeRule('2', '/a/b')];
-  const r = selectMostSpecificRule('/a/b', rules, RULE_MATCHING_CONFIG);
-  assert.equal(r?.matcher, '/a/b');
+  const rules = [makeRule("1", "/a/*"), makeRule("2", "/a/b")];
+  const r = selectMostSpecificRule("/a/b", rules, RULE_MATCHING_CONFIG);
+  assert.equal(r?.matcher, "/a/b");
 }
 
 // Wildcard with query enriched rule
 {
-  const rules = [makeRule('1', '/a/:id/c'), makeRule('2', '/a/123/c?x=1')];
-  const r = selectMostSpecificRule('/a/123/c?x=1', rules, RULE_MATCHING_CONFIG);
-  assert.equal(r?.matcher, '/a/123/c?x=1');
+  const rules = [makeRule("1", "/a/:id/c"), makeRule("2", "/a/123/c?x=1")];
+  const r = selectMostSpecificRule("/a/123/c?x=1", rules, RULE_MATCHING_CONFIG);
+  assert.equal(r?.matcher, "/a/123/c?x=1");
 }
 
 // Trailing slash equivalence
 {
-  const rules = [makeRule('1', '/x/y', 0), makeRule('2', '/x/y/', 1)];
-  const r = selectMostSpecificRule('/x/y/', rules, RULE_MATCHING_CONFIG);
-  assert.equal(r?.id, '1');
+  const rules = [makeRule("1", "/x/y", 0), makeRule("2", "/x/y/", 1)];
+  const r = selectMostSpecificRule("/x/y/", rules, RULE_MATCHING_CONFIG);
+  assert.equal(r?.id, "1");
 }
 
 // Multi-query order
 {
-  const rules = [makeRule('1', '/p?q=1&q=2'), makeRule('2', '/p?q=2&q=1')];
-  const r = selectMostSpecificRule('/p?q=2&q=1', rules, RULE_MATCHING_CONFIG);
-  assert.equal(r?.id, '1');
+  const rules = [makeRule("1", "/p?q=1&q=2"), makeRule("2", "/p?q=2&q=1")];
+  const r = selectMostSpecificRule("/p?q=2&q=1", rules, RULE_MATCHING_CONFIG);
+  assert.equal(r?.id, "1");
 }
 
 // Deterministic tie-breaker
 {
-  const rules = [makeRule('1', '/same'), makeRule('2', '/same', 1)];
-  const r = selectMostSpecificRule('/same', rules, RULE_MATCHING_CONFIG);
-  assert.equal(r?.id, '1');
+  const rules = [makeRule("1", "/same"), makeRule("2", "/same", 1)];
+  const r = selectMostSpecificRule("/same", rules, RULE_MATCHING_CONFIG);
+  assert.equal(r?.id, "1");
 }
 
 // Performance smoke test
@@ -78,10 +96,10 @@ function makeRule(id: string, matcher: string, createdOffset = 0): UrlRule {
     bigRules.push(makeRule(String(i), `/p/${i}`));
   }
   const start = Date.now();
-  const r = selectMostSpecificRule('/p/9999', bigRules, RULE_MATCHING_CONFIG);
+  const r = selectMostSpecificRule("/p/9999", bigRules, RULE_MATCHING_CONFIG);
   const duration = Date.now() - start;
-  assert.equal(r?.matcher, '/p/9999');
+  assert.equal(r?.matcher, "/p/9999");
   assert.ok(duration < 1000, `Performance too slow: ${duration}ms`);
 }
 
-console.log('specificity tests passed');
+console.log("specificity tests passed");

--- a/test-server-features.js
+++ b/test-server-features.js
@@ -1,40 +1,40 @@
-import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import express from 'express';
-import session from 'express-session';
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import session from "express-session";
 
 // Prepare isolated working directory with required data files
-const repoDataDir = new URL('./data', import.meta.url);
-const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'srs-test-'));
-fs.mkdirSync(path.join(tempDir, 'data'), { recursive: true });
+const repoDataDir = new URL("./data", import.meta.url);
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "srs-test-"));
+fs.mkdirSync(path.join(tempDir, "data"), { recursive: true });
 // Copy existing data files to temp directory
-fs.cpSync(repoDataDir, path.join(tempDir, 'data'), { recursive: true });
+fs.cpSync(repoDataDir, path.join(tempDir, "data"), { recursive: true });
 // Ensure sessions directory exists for health check
-fs.mkdirSync(path.join(tempDir, 'data', 'sessions'), { recursive: true });
+fs.mkdirSync(path.join(tempDir, "data", "sessions"), { recursive: true });
 
 process.chdir(tempDir);
 
 // Dynamic imports after changing working directory so storage uses temp data path
-const { registerRoutes } = await import('./server/routes.ts');
-const { FileSessionStore } = await import('./server/fileSessionStore.ts');
+const { registerRoutes } = await import("./server/routes.ts");
+const { FileSessionStore } = await import("./server/fileSessionStore.ts");
 
 // Helper to start server on random port
 async function startServer() {
   const app = express();
-  app.use(express.json({ limit: '50mb' }));
-  app.use(express.urlencoded({ extended: false, limit: '50mb' }));
+  app.use(express.json({ limit: "50mb" }));
+  app.use(express.urlencoded({ extended: false, limit: "50mb" }));
   const sessionMiddleware = session({
     store: new FileSessionStore(),
-    secret: 'test-secret',
+    secret: "test-secret",
     resave: false,
     saveUninitialized: false,
-    cookie: { maxAge: 60000 }
+    cookie: { maxAge: 60000 },
   });
-  app.use('/api/admin', sessionMiddleware);
+  app.use("/api/admin", sessionMiddleware);
   const httpServer = await registerRoutes(app);
-  await new Promise(resolve => httpServer.listen(0, resolve));
+  await new Promise((resolve) => httpServer.listen(0, resolve));
   const port = httpServer.address().port;
   return { httpServer, port };
 }
@@ -44,51 +44,59 @@ const { httpServer, port } = await startServer();
 async function request(pathname, options = {}) {
   const res = await fetch(`http://localhost:${port}${pathname}`, {
     ...options,
-    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
   });
   let body = null;
   const text = await res.text();
-  try { body = JSON.parse(text); } catch {}
+  try {
+    body = JSON.parse(text);
+  } catch {}
   return { res, body };
 }
 
 try {
   // Health check should report healthy
   {
-    const { res, body } = await request('/api/health');
+    const { res, body } = await request("/api/health");
     assert.equal(res.status, 200);
-    assert.equal(body.status, 'healthy');
+    assert.equal(body.status, "healthy");
   }
 
   // Accessing admin route without auth should fail
   {
-    const { res } = await request('/api/admin/rules');
+    const { res } = await request("/api/admin/rules");
     assert.equal(res.status, 403);
   }
 
   // Successful login
-  const login = await request('/api/admin/login', {
-    method: 'POST',
-    body: JSON.stringify({ password: 'Password1' }),
+  const login = await request("/api/admin/login", {
+    method: "POST",
+    body: JSON.stringify({ password: "Password1" }),
   });
   assert.equal(login.res.status, 200);
   assert.ok(login.body.success);
-  const rawCookie = login.res.headers.get('set-cookie');
+  const rawCookie = login.res.headers.get("set-cookie");
   assert.ok(rawCookie);
-  const cookie = rawCookie.split(';')[0];
+  const cookie = rawCookie.split(";")[0];
 
   // Authenticated status check
   {
-    const { res, body } = await request('/api/admin/status', { headers: { cookie } });
+    const { res, body } = await request("/api/admin/status", {
+      headers: { cookie },
+    });
     assert.equal(res.status, 200);
     assert.equal(body.isAuthenticated, true);
   }
 
   // Create a new URL rule
   {
-    const newRule = { matcher: '/test-rule', targetUrl: '/new-url', redirectType: 'partial' };
-    const { res, body } = await request('/api/admin/rules', {
-      method: 'POST',
+    const newRule = {
+      matcher: "/test-rule",
+      targetUrl: "/new-url",
+      redirectType: "partial",
+    };
+    const { res, body } = await request("/api/admin/rules", {
+      method: "POST",
       headers: { cookie },
       body: JSON.stringify(newRule),
     });
@@ -96,11 +104,27 @@ try {
     assert.equal(body.matcher, newRule.matcher);
   }
 
-  console.log('Server feature tests passed');
-  await new Promise(resolve => httpServer.close(resolve));
+  // Creating overlapping rule should fail
+  {
+    const overlappingRule = {
+      matcher: "/foo/test-rule",
+      targetUrl: "/other",
+      redirectType: "partial",
+    };
+    const { res, body } = await request("/api/admin/rules", {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify(overlappingRule),
+    });
+    assert.equal(res.status, 400);
+    assert.match(body.error, /Überlappender URL-Matcher/);
+  }
+
+  console.log("Server feature tests passed");
+  await new Promise((resolve) => httpServer.close(resolve));
   process.exit(0);
 } catch (error) {
-  await new Promise(resolve => httpServer.close(resolve));
+  await new Promise((resolve) => httpServer.close(resolve));
   console.error(error);
   process.exit(1);
 }

--- a/test-url-transformation.js
+++ b/test-url-transformation.js
@@ -1,34 +1,32 @@
-
 // Test script to verify URL transformation logic
 
-import fs from 'node:fs';
-import assert from 'node:assert/strict';
-import { selectMostSpecificRule } from './shared/ruleMatching.ts';
-import { RULE_MATCHING_CONFIG } from './shared/constants.ts';
-
+import fs from "node:fs";
+import assert from "node:assert/strict";
+import { selectMostSpecificRule } from "./shared/ruleMatching.ts";
+import { RULE_MATCHING_CONFIG } from "./shared/constants.ts";
 
 // Load sample rules used for testing
-const rulesPath = new URL('./data/rules.json', import.meta.url);
-const rules = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
+const rulesPath = new URL("./data/rules.json", import.meta.url);
+const rules = JSON.parse(fs.readFileSync(rulesPath, "utf-8"));
 
 function findMatchingRule(path) {
   return selectMostSpecificRule(path, rules, RULE_MATCHING_CONFIG);
 }
 
-function generateUrl(path, rule, domain = 'https://newurlofdifferentapp.com') {
-  const base = domain.replace(/\/$/, '');
+function generateUrl(path, rule, domain = "https://newurlofdifferentapp.com") {
+  const base = domain.replace(/\/$/, "");
   if (!rule) {
     return base + path;
   }
-  if (rule.redirectType === 'wildcard') {
+  if (rule.redirectType === "wildcard") {
     return rule.targetUrl;
   }
-  const cleanMatcher = rule.matcher.replace(/\/$/, '');
-  const cleanTarget = rule.targetUrl.replace(/^\/|\/$/g, '');
+  const cleanMatcher = rule.matcher.replace(/\/$/, "");
+  const cleanTarget = rule.targetUrl.replace(/^\/|\/$/g, "");
   const idx = path.toLowerCase().indexOf(cleanMatcher.toLowerCase());
-  const before = idx !== -1 ? path.slice(0, idx) : '';
-  const after = idx !== -1 ? path.slice(idx + cleanMatcher.length) : '';
-  const newPath = `${before}/${cleanTarget}${after}`.replace(/\/+/g, '/');
+  const before = idx !== -1 ? path.slice(0, idx) : "";
+  const after = idx !== -1 ? path.slice(idx + cleanMatcher.length) : "";
+  const newPath = `${before}/${cleanTarget}${after}`.replace(/\/+/g, "/");
   return base + newPath;
 }
 
@@ -38,7 +36,11 @@ async function testScenario(name, path, expectedType, expectedResult) {
     assert.strictEqual(rule, null, `${name}: expected no rule`);
   } else {
     assert.ok(rule, `${name}: expected rule`);
-    assert.strictEqual(rule.redirectType, expectedType, `${name}: type mismatch`);
+    assert.strictEqual(
+      rule.redirectType,
+      expectedType,
+      `${name}: type mismatch`,
+    );
   }
   const newUrl = generateUrl(path, rule);
   assert.strictEqual(newUrl, expectedResult, `${name}: URL mismatch`);
@@ -46,33 +48,45 @@ async function testScenario(name, path, expectedType, expectedResult) {
 
 async function run() {
   await testScenario(
-    'Test 1: Wildcard rule (Vollständig)',
-    '/sample-old-path-full',
-    'wildcard',
-    'https://newurlofdifferentapp.com/sample-new-path'
+    "Test 1: Wildcard rule (Vollständig)",
+    "/sample-old-path-full",
+    "wildcard",
+    "https://newurlofdifferentapp.com/sample-new-path",
   );
   await testScenario(
-    'Test 2: Partial rule (Teilweise)',
-    '/sample-old-path/006002',
-    'partial',
-    'https://newurlofdifferentapp.com/sample-new-path/006002'
+    "Test 2: Partial rule (Teilweise)",
+    "/sample-old-path/006002",
+    "partial",
+    "https://newurlofdifferentapp.com/sample-new-path/006002",
   );
   await testScenario(
-    'Test 3: No matching rule',
-    '/no-rule-matches-this',
+    "Test 3: No matching rule",
+    "/no-rule-matches-this",
     null,
-    'https://newurlofdifferentapp.com/no-rule-matches-this'
+    "https://newurlofdifferentapp.com/no-rule-matches-this",
   );
   await testScenario(
-    'Test 4: Wildcard rule ignores additional segments',
-    '/sample-old-path-full/006965',
-    'wildcard',
-    'https://newurlofdifferentapp.com/sample-new-path'
+    "Test 4: Wildcard rule ignores additional segments",
+    "/sample-old-path-full/006965",
+    "wildcard",
+    "https://newurlofdifferentapp.com/sample-new-path",
   );
-  console.log('All tests passed');
+  await testScenario(
+    "Test 5: Partial rule match in sub-path",
+    "/foo/sample-old-path/123",
+    "partial",
+    "https://newurlofdifferentapp.com/foo/sample-new-path/123",
+  );
+  await testScenario(
+    "Test 6: Wildcard rule match in sub-path",
+    "/foo/sample-old-path-full/999",
+    "wildcard",
+    "https://newurlofdifferentapp.com/sample-new-path",
+  );
+  console.log("All tests passed");
 }
 
-run().catch(err => {
+run().catch((err) => {
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- allow rule matcher to match anywhere within request path
- align overlap validation and messages with new matching logic
- document path-agnostic matching behavior

## Testing
- `npx eslint shared/ruleMatching.ts shared/utils.ts server/storage.ts test-rule-specificity.ts test-url-transformation.js test-server-features.js` *(fails: ESLint couldn't find config)*
- `npm test`
- `npm audit` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a09e2a3d88331905e9b22c450baf0