### PR TITLE
feat: add optional UrlFilter parameter to Update-OfficeLinks.ps1

### DIFF
--- a/scripts/Update-OfficeLinks.ps1
+++ b/scripts/Update-OfficeLinks.ps1
@@ -29,6 +29,10 @@
     Die URL zum Transform API Endpoint der SmartRedirect Suite.
     Standard: "https://yourdomain.com/api/public/transform"
 
+.PARAMETER UrlFilter
+    Optionaler Regex-Filter. Wenn gesetzt, werden nur Hyperlinks verarbeitet,
+    deren URL auf diesen regulären Ausdruck zutrifft (z.B. "intranet\.corp\.com").
+
 .PARAMETER ExportToPDF
     Optionaler Schalter. Wenn gesetzt, wird jedes verarbeitete Dokument zusätzlich als PDF
     exportiert (im selben Verzeichnis, gleicher Name, Endung .pdf).
@@ -47,6 +51,9 @@ param (
 
     [Parameter(Mandatory=$false)]
     [string]$ApiEndpoint = "https://yourdomain.com/api/public/transform",
+
+    [Parameter(Mandatory=$false)]
+    [string]$UrlFilter,
 
     [switch]$ExportToPDF,
 
@@ -134,6 +141,9 @@ if ($wordFiles.Count -gt 0) {
                 $linksChanged = $false
 
                 foreach ($hyperlink in $doc.Hyperlinks) {
+                    if ($UrlFilter -and $hyperlink.Address -notmatch $UrlFilter) {
+                        continue
+                    }
                     if (-not [string]::IsNullOrEmpty($hyperlink.Address)) {
                         $newUrl = Get-TransformedUrl -Url $hyperlink.Address
                         if ($newUrl -and $newUrl -ne $hyperlink.Address) {
@@ -195,6 +205,9 @@ if ($excelFiles.Count -gt 0) {
 
                 foreach ($ws in $wb.Worksheets) {
                     foreach ($hyperlink in $ws.Hyperlinks) {
+                        if ($UrlFilter -and $hyperlink.Address -notmatch $UrlFilter) {
+                            continue
+                        }
                         if (-not [string]::IsNullOrEmpty($hyperlink.Address)) {
                             $newUrl = Get-TransformedUrl -Url $hyperlink.Address
                             if ($newUrl -and $newUrl -ne $hyperlink.Address) {
@@ -258,6 +271,9 @@ if ($pptFiles.Count -gt 0) {
 
                 foreach ($slide in $presentation.Slides) {
                     foreach ($hyperlink in $slide.Hyperlinks) {
+                        if ($UrlFilter -and $hyperlink.Address -notmatch $UrlFilter) {
+                            continue
+                        }
                         if (-not [string]::IsNullOrEmpty($hyperlink.Address)) {
                             $newUrl = Get-TransformedUrl -Url $hyperlink.Address
                             if ($newUrl -and $newUrl -ne $hyperlink.Address) {


### PR DESCRIPTION
Added an optional `-UrlFilter` parameter to the `Update-OfficeLinks.ps1` script to allow targeted processing of URLs. When provided, the script uses PowerShell's `-notmatch` operator to skip any hyperlink whose address does not match the given regex pattern.

Changes:
*   Added `[string]$UrlFilter` to the `param` block of `scripts/Update-OfficeLinks.ps1`.
*   Added `.PARAMETER UrlFilter` documentation in the script's `.SYNOPSIS` block explaining its regex-based usage.
*   Injected filtering logic `if ($UrlFilter -and $hyperlink.Address -notmatch $UrlFilter) { continue }` inside the processing loops for Word, Excel, and PowerPoint files.

---
*PR created automatically by Jules for task [3529287509375268161](https://jules.google.com/task/3529287509375268161) started by @DrunkenHusky*