### PR TITLE
fix: remove external network calls to Google favicon service from admin dashboard

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -4269,12 +4269,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                                       <td className="p-2 sm:p-3 text-sm font-medium">#{rank}</td>
                                       <td className="p-2 sm:p-3">
                                         <div className="flex items-center gap-2">
-                                          <img
-                                            src={`https://www.google.com/s2/favicons?domain=${ref.domain}&sz=16`}
-                                            alt=""
-                                            className="w-4 h-4 opacity-70"
-                                            onError={(e) => e.currentTarget.style.display = 'none'}
-                                          />
                                           <span className="text-xs sm:text-sm text-foreground truncate max-w-[150px] sm:max-w-[200px]" title={ref.domain}>
                                             {ref.domain}
                                           </span>


### PR DESCRIPTION
This PR addresses the user's request to prevent the application from making external network calls to third-party services (specifically Google Favicons) from the frontend UI. 

### Changes Made:
- Removed the `<img>` tag in `client/src/pages/admin.tsx` that previously fetched a website's favicon from `https://www.google.com/s2/favicons` to display it next to the site domain in the `Top Referrer` list on the Admin Dashboard's `Statistiken` tab.
- This effectively stops all calls to both `google.com` and its redirect endpoint `t0.gstatic.com` when viewing statistics.

### Additional Notes:
- An audit of the codebase was performed, searching for any other hardcoded external requests (`https://...`). All remaining URLs in the codebase are strictly placeholders (`"https://..."`) or user-configurable default endpoints (`"https://thisisthenewurl.com/"`) and are not invoked actively as external trackers or network calls.
- Removed dev artifacts created during testing. All integration tests and unit tests passed smoothly.

---
*PR created automatically by Jules for task [12869621966741232110](https://jules.google.com/task/12869621966741232110) started by @DrunkenHusky*