### PR TITLE
Make admin settings save buttons sticky

### DIFF
--- a/client/src/components/admin/GlobalRulesSettings.tsx
+++ b/client/src/components/admin/GlobalRulesSettings.tsx
@@ -349,7 +349,7 @@ export function GlobalRulesSettings({ settings, onUpdate, onSave, isSaving, onOp
                 </div>
 
                 {/* Save Button */}
-                <div className="border-t pt-6 mt-8">
+                <div className="sticky bottom-0 z-40 bg-card border-t pt-4 pb-4 mt-8 px-4 sm:px-6 -mx-4 sm:-mx-6 -mb-4 sm:-mb-6 rounded-b-xl shadow-[0_-10px_15px_-3px_rgba(0,0,0,0.05)] dark:shadow-[0_-10px_15px_-3px_rgba(0,0,0,0.2)]">
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm text-muted-foreground">

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -3536,7 +3536,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                       </div>
 
                     {/* Save Button */}
-                    <div className="border-t pt-6 mt-8">
+                    <div className="sticky bottom-0 z-40 bg-card border-t pt-4 pb-4 mt-8 px-4 sm:px-6 -mx-4 sm:-mx-6 -mb-4 sm:-mb-6 rounded-b-xl shadow-[0_-10px_15px_-3px_rgba(0,0,0,0.05)] dark:shadow-[0_-10px_15px_-3px_rgba(0,0,0,0.2)]">
                       <div className="flex items-center justify-between">
                         <div>
                           <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
I have updated the "Speichern Sie Ihre Änderungen um sie auf der Website anzuwenden." sections in `client/src/pages/admin.tsx` (General Settings Tab) and `client/src/components/admin/GlobalRulesSettings.tsx` (Global Rules Tab) to use Tailwind's `sticky bottom-0 z-40 bg-card` classes. This ensures the "Save Settings" button remains visible as a sticky footer while scrolling through the long settings forms.

---
*PR created automatically by Jules for task [14650778473904222175](https://jules.google.com/task/14650778473904222175) started by @DrunkenHusky*