### PR TITLE
refactor: clean up unused variables, imports, and state\n\n- Removed …

### DIFF
--- a/client/src/components/admin/ValidationModal.tsx
+++ b/client/src/components/admin/ValidationModal.tsx
@@ -20,7 +20,7 @@ interface ValidationModalProps {
     isLoadingRules?: boolean;
 }
 
-function ResultRow({ result, index, isExpanded, onToggle, onEditRule }: { result: any, index: number, isExpanded: boolean, onToggle: () => void, onEditRule: (id: number) => void }) {
+function ResultRow({ result, isExpanded, onToggle, onEditRule }: { result: any, isExpanded: boolean, onToggle: () => void, onEditRule: (id: number) => void }) {
     // Helper to get step styles
     const getStepStyle = (step: any) => {
         if (!step.changed) {
@@ -237,7 +237,7 @@ function ResultRow({ result, index, isExpanded, onToggle, onEditRule }: { result
     );
 }
 
-export function ValidationModal({ open, onOpenChange, onEditRule, rules = [], settings, reloadTrigger, isLoadingRules = false }: ValidationModalProps) {
+export function ValidationModal({ open, onOpenChange, onEditRule, reloadTrigger, isLoadingRules = false }: ValidationModalProps) {
     const [pastedText, setPastedText] = useState("");
     const [activeTab, setActiveTab] = useState("paste");
     const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -569,7 +569,6 @@ export function ValidationModal({ open, onOpenChange, onEditRule, rules = [], se
                                                 <ResultRow
                                                     key={i}
                                                     result={result}
-                                                    index={i}
                                                     isExpanded={expandedRows.has(i)}
                                                     onToggle={() => toggleRow(i)}
                                                     onEditRule={onEditRule}

--- a/client/src/components/ui/quality-gauge.tsx
+++ b/client/src/components/ui/quality-gauge.tsx
@@ -11,14 +11,10 @@ interface QualityGaugeProps {
 export function QualityGauge({ score, level, explanation }: QualityGaugeProps) {
   // Determine color classes
   let colorClass = "text-green-600 bg-green-50";
-  let iconColor = "#16a34a"; // green-600
-
   if (level === 'red') {
     colorClass = "text-red-600 bg-red-50";
-    iconColor = "#dc2626"; // red-600
   } else if (level === 'yellow') {
     colorClass = "text-yellow-600 bg-yellow-50";
-    iconColor = "#ca8a04"; // yellow-600
   }
 
   return (

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -17,8 +17,7 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader, 
-  DialogTitle, 
-  DialogTrigger 
+  DialogTitle
 } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 import { 
@@ -30,13 +29,11 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { 
   Shield, 
   X, 
   Plus, 
-  Edit, 
   Trash2, 
   Download, 
   Upload,
@@ -52,7 +49,6 @@ import {
   RefreshCw,
   Trash,
   Search,
-  ArrowUpDown,
   ArrowUp,
   ArrowDown,
   ArrowRightLeft,
@@ -414,7 +410,6 @@ export default function AdminPage({ onClose }: AdminPageProps) {
 
   // Statistics filters and state
   const [statsFilter, setStatsFilter] = useState('all' as '24h' | '7d' | 'all');
-  const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState('timestamp');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [statsView, setStatsView] = useState<'top100' | 'browser'>(() => {
@@ -1248,7 +1243,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
       if (showValidationModal) setShowValidationReloadDialog(true);
       toast({ title: "Regel erstellt", description: "Die URL-Regel wurde trotz Warnung erfolgreich erstellt." });
     },
-    onError: (error: any) => {
+    onError: () => {
       toast({ 
         title: "Fehler", 
         description: "Die Regel konnte auch mit Force-Option nicht erstellt werden.",
@@ -1270,7 +1265,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
       if (showValidationModal) setShowValidationReloadDialog(true);
       toast({ title: "Regel aktualisiert", description: "Die URL-Regel wurde trotz Warnung erfolgreich aktualisiert." });
     },
-    onError: (error: any) => {
+    onError: () => {
       toast({ 
         title: "Fehler", 
         description: "Die Regel konnte auch mit Force-Option nicht aktualisiert werden.",
@@ -1803,16 +1798,9 @@ export default function AdminPage({ onClose }: AdminPageProps) {
     }
   };
 
-  const getSortIcon = (column: string) => {
-    if (sortBy !== column) return <ArrowUpDown className="h-4 w-4" />;
-    return sortOrder === 'asc' ? <ArrowUp className="h-4 w-4" /> : <ArrowDown className="h-4 w-4" />;
-  };
-
   const formatTimestamp = (timestamp: string) => {
     return new Date(timestamp).toLocaleString('de-DE');
   };
-
-  const maxCount = statsData?.topUrls?.[0]?.count || 1;
 
   const handlePreview = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -2231,7 +2219,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                                               throw new Error(`HTTP ${response.status}: ${response.statusText}`);
                                             }
                                             
-                                            const deleteData = await response.json();
+                                            await response.json();
                                             
                                             // Update local state to immediately remove logo URL
                                             setGeneralSettings(prev => ({

--- a/client/src/pages/migration.tsx
+++ b/client/src/pages/migration.tsx
@@ -18,7 +18,6 @@ import {
   Bookmark,
   Share2,
   Clock,
-  BarChart3,
   Settings,
   Star,
   Heart,
@@ -78,7 +77,7 @@ export default function MigrationPage({ onAdminAccess }: MigrationPageProps) {
   const [infoText, setInfoText] = useState("");
   const [showPasswordModal, setShowPasswordModal] = useState(false);
   const [showMainDialog, setShowMainDialog] = useState(false);
-  const [showUrlComparison, setShowUrlComparison] = useState(true);
+  const showUrlComparison = true;
   const [copySuccess, setCopySuccess] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
   const [isLoading, setIsLoading] = useState(true);

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -19,7 +19,7 @@ export function errorHandler(
   error: ErrorWithCode,
   req: Request,
   res: Response,
-  next: NextFunction
+  _next: NextFunction
 ): void {
   // Log error with context
   const errorContext = {

--- a/server/middleware/validation.ts
+++ b/server/middleware/validation.ts
@@ -5,7 +5,6 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import { z, ZodSchema, ZodError } from 'zod';
-import { createError } from './errorHandler';
 
 /**
  * Validation middleware factory

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,7 +17,7 @@ import { LocalFileUploadService } from "./localFileUpload";
 import { bruteForceProtection, recordLoginFailure, resetLoginAttempts, resetAllLoginAttempts, getBlockedIps, blockIp } from "./middleware/bruteForce";
 import { apiRateLimiter, trackingRateLimiter } from "./middleware/rateLimit";
 import path from "path";
-import { findMatchingRule, findAllMatchingRules } from "@shared/ruleMatching";
+import { findMatchingRule } from "@shared/ruleMatching";
 import { RULE_MATCHING_CONFIG } from "@shared/constants";
 import { APPLICATION_METADATA } from "@shared/appMetadata";
 import { ImportExportService } from "./import-export";
@@ -927,9 +927,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
             const feedback = track.feedback || '';
             const quality = track.matchQuality !== undefined ? track.matchQuality : 0;
             const userProposedUrl = track.userProposedUrl || '';
-            const strategy = track.redirectStrategy || '';
-            const globalRules = (track.appliedGlobalRules || []).map(r => r.description).join('; ');
-
             if (includeReferrer) {
               return `"${track.id}","${track.oldUrl}","${(track as any).newUrl || ''}","${track.path}","${track.referrer || ''}","${track.timestamp}","${track.userAgent || ''}","${ruleId}","${feedback}","${quality}","${userProposedUrl}"`;
             } else {

--- a/shared/ruleMatching.ts
+++ b/shared/ruleMatching.ts
@@ -73,7 +73,7 @@ export function normalizeQuery(
     if (!map.has(normKey)) map.set(normKey, []);
     map.get(normKey)!.push(decodeURIComponent(value));
   }
-  for (const [key, arr] of map) {
+  for (const [_, arr] of map) {
     arr.sort();
   }
   return map;

--- a/shared/url-trace.ts
+++ b/shared/url-trace.ts
@@ -145,7 +145,6 @@ export function traceUrlGeneration(
       } else {
           // Path replacement
           if (workingOldPath.startsWith(cleanMatcher) || workingOldPath.toLowerCase().startsWith(cleanMatcher.toLowerCase())) {
-              const suffix = workingOldPath.substring(cleanMatcher.length);
 
               let targetBase = rawTarget;
               // NOTE: Smart slash handling and suffix appending removed to implement FULL REPLACEMENT.

--- a/shared/url-utils.ts
+++ b/shared/url-utils.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 export interface SmartSearchRule {
   pattern?: string;
   order: number;


### PR DESCRIPTION
…unused `ResultRow` index prop and `rules` prop from `ValidationModal`.\n- Cleaned up unused Lucide icons, `AlertDialogTrigger`, state functions (`setSearchQuery`), and helper functions (`getSortIcon`) from `admin.tsx`.\n- Removed unused states and icons from `migration.tsx`.\n- Fixed TypeScript warnings related to the `errorHandler` middleware by explicitly marking the `next` param as ignored (`_next`) while preserving the signature.\n- Removed unused API imports (`createError`, `findAllMatchingRules`, `zod`).\n- Removed unused variable `suffix` in `url-trace.ts`.\n- Simplified unused object mapping keys in `ruleMatching.ts`.