### PR TITLE
fix: resolve white screen on load caused by undefined useTranslation in PasswordModal

### DIFF
--- a/client/src/components/ui/password-modal.tsx
+++ b/client/src/components/ui/password-modal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,6 +13,7 @@ interface PasswordModalProps {
 }
 
 export function PasswordModal({ isOpen, onClose, onSuccess }: PasswordModalProps) {
+  const { t } = useTranslation();
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
This PR fixes an issue where the app would fail to load and show a white screen. The `PasswordModal` component was using the `t()` function from `react-i18next` for translations but it had not imported and initialized `useTranslation()`. 

The fix correctly imports `useTranslation` and initializes `t()` within the component. Tests have been run and a visual verification using a Playwright script was done to ensure the password modal opens correctly and the app is rendering properly without errors.

---
*PR created automatically by Jules for task [15546863780732507406](https://jules.google.com/task/15546863780732507406) started by @DrunkenHusky*