### PR TITLE
docs: translate all documentation to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # SmartRedirect Suite
 
-SmartRedirect Suite ist eine Web-Anwendung zur zentralen Verwaltung von URL‑Migrationen zwischen alter und neuer Domain. Typischer Use Case: Migration von SharePoint On-Premises zu SharePoint Online, wenn sich Domain und Pfadstruktur ändern. Die App weist Nutzer auf veraltete Links hin und kann automatisch auf neue Ziele weiterleiten.
+SmartRedirect Suite is a web application for centrally managing URL migrations between old and new domains. Typical use case: Migrating from SharePoint On-Premises to SharePoint Online when the domain and path structure change. The app notifies users of outdated links and can automatically redirect to new destinations.
 
 **Demo-Instanz:** [smartredirectsuite.render.com](https://smartredirectsuite.onrender.com/)
-Diese Version basiert stets auf dem neuesten Dev-Build, wird alle 24 Stunden zurückgesetzt und eignet sich zum Ausprobieren der App.
+This version is always based on the latest dev build, resets every 24 hours and is suitable for trying out the app.
 
-☕️ **Kaffee für den Code?** Wenn dir die SmartRedirect Suite gefällt, spendier mir auf [BuyMeACoffee](https://buymeacoffee.com/drunkenhusky) einen Kaffee und halte die Bits am Koffein!
+☕️ **Coffee for the code?** If you like the SmartRedirect Suite, buy me a coffee on [BuyMeACoffee](https://buymeacoffee.com/drunkenhusky) and keep the bits caffeinated!
 
 ## Table of Contents
 
@@ -19,107 +19,107 @@ Diese Version basiert stets auf dem neuesten Dev-Build, wird alle 24 Stunden zu
 - [Quick Start](#schnellstart)
   - [Prerequisites](#voraussetzungen)
   - [1. Repository klonen](#1-repository-klonen)
-  - [2. Dependencies installieren](#2-dependencies-installieren)
-  - [3. .env-Datei erstellen](#3-env-datei-erstellen)
-  - [4. Anwendung starten](#4-anwendung-starten)
+  - [2. Install Dependencies](#2-dependencies-installieren)
+  - [3. Create .env file](#3-env-datei-erstellen)
+  - [4. Start Application](#4-anwendung-starten)
 - [Administration](#administration)
-  - [Regeln importieren](#regeln-importieren)
-  - [Einstellungen anpassen](#einstellungen-anpassen)
+  - [Import Rules](#regeln-importieren)
+  - [Customize Settings](#einstellungen-anpassen)
   - [Matching Indicator](#matching-indicator)
-  - [Statistiken & Monitoring](#statistiken--monitoring)
-- [Release Prozess](#release-prozess)
-- [Validierung & Qualitätssicherung](#validierung--qualitatssicherung)
-- [Datenverwaltung](#datenverwaltung)
-- [Sicherheit](#sicherheit)
+  - [Statistics & Monitoring](#statistiken--monitoring)
+- [Release Process](#release-prozess)
+- [Validation & Quality Assurance](#validierung--qualitatssicherung)
+- [Data Management](#datenverwaltung)
+- [Security](#sicherheit)
 - [Deployment](#deployment)
-- [Entwicklung](#entwicklung)
+- [Development](#entwicklung)
 - [Support & Beitrag](#support--beitrag)
-- [Änderungshistorie](#anderungshistorie)
+- [Change History](#anderungshistorie)
 
 ## Key Features
 
-- Zentrale Regelverwaltung mit automatischer URL-Erkennung
-- Kontrollierte Migrationen und nachvollziehbare Domainwechsel
-- Produktivität: Multi-Select, Import/Export von Regeln
-- Admin-Panel mit persistenter Session und anpassbarer UI
-- Intelligente Validierung mit Überlappungserkennung
-- Umfangreiche Statistiken und URL-Tracking
-- Skalierbare Architektur: Verarbeitung von über 100'000 Regeln und Logeinträgen ohne Leistungseinbussen
-- Responsives Design für Desktop und Mobilgeräte
+- Central rule management with automatic URL detection
+- Controlled migrations and traceable domain changes
+- Productivity: Multi-select, import/export of rules
+- Admin panel with persistent session and customizable UI
+- Intelligent validation with overlap detection
+- Extensive statistics and URL tracking
+- Scalable architecture: Processing of over 100,000 rules and log entries without sacrificing performance
+- Responsive design for desktop and mobile devices
 
 ## Documentation
 
 - [User Manual](./docs/USER_MANUAL.md)
 - [Admin-Documentation](./docs/ADMIN_DOCUMENTATION.md)
 - [Docker Deployment](./docs/DOCKER_DEPLOYMENT.md)
-- [Architektur-Overview](./docs/ARCHITECTURE_OVERVIEW.md)
+- [Architecture Overview](./docs/ARCHITECTURE_OVERVIEW.md)
 - [Configuration Examples](./docs/CONFIGURATION_EXAMPLES.md)
 - [Release Pipeline](./docs/release-pipeline.md)
 
 ## Impressions
 
-Kurzer Überblick über zentrale Screens der SmartRedirect Suite.
+Brief overview of central screens of the SmartRedirect Suite.
 
-### Website-Besucher
+### Website visitors
 
-1. **Initiale Meldung** – Hinweis, dass der verwendete Link veraltet ist und aktualisiert werden soll.  
-   ![Initiale Meldung – Website Besucher](Impressions/Initiale%20Meldung%20Website%20Besucher.png)
+1. **Initial message** - Notice that the link used is out of date and should be updated.
+![Initial message – website visitor](Impressions/Initiale%20Meldung%20Website%20Besucher.png)
 
-2. **Neue URL mit Hinweisen** – Anzeige der automatisch generierten neuen URL inkl. Hinweise sowie der alten, aufgerufenen URL.  
-   ![Anzeige neuer URL mit Hinweisen – Website Besucher nach Bestätigung Pop-up](Impressions/Anzeige%20neuer%20URL%20mit%20Hinweisen%20Website%20Besucher%20nach%20Best%C3%A4tigung%20Pop%20up.png)
+2. **New URL with notes** – Display of the automatically generated new URL including notes as well as the old, accessed URL.
+![Display new URL with information - website visitors pop-up after confirmation](Impressions/Anzeige%20neuer%20URL%20mit%20Hinweisen%20Website%20Besucher%20nach%20Best%C3%A4tigung%20Pop%20up.png)
 
-### Admin-Bereich
+### Admin area
 
-3. **Generelle Einstellungen** – Overview über globale Optionen und Grundkonfiguration.
-   ![Admin Menü – Generelle Einstellungen](Impressions/Admin%20Menu%20Generelle%20Einstellungen.png)
+3. **General Settings** – Overview of global options and basic configuration.
+![Admin Menu – General Settings](Impressions/Admin%20Menu%20Generelle%20Einstellungen.png)
 
-4. **URL-Transformationsregeln** – Verwaltung von Regeln (Typ, Auto-Redirect, Status, Metadaten).  
-   ![Admin Menu – URL-Transformationsregeln definieren](Impressions/Admin%20Menu%20URL-Transformationsregeln%20definieren.png)
+4. **URL Transformation Rules** – Management of rules (type, auto-redirect, status, metadata).
+![Admin Menu – Define URL transformation rules](Impressions/Admin%20Menu%20URL-Transformationsregeln%20definieren.png)
 
-5. **Statistiken & Tracking** – Liste aller Tracking-Einträge mit Zeitstempel, alter/neuer URL und Pfad.  
-   ![Admin Menu – Statistik](Impressions/Admin%20Menu%20Statistik.png)
+5. **Statistics & Tracking** – List of all tracking entries with timestamp, old/new URL and path.
+![Admin Menu – Statistics](Impressions/Admin%20Menu%20Statistik.png)
 
-6. **Import/Export** – Export von Statistiken (CSV/JSON) sowie Import/Export der URL-Regeln.  
-   ![Admin Menu – Import Export](Impressions/Admin%20Menu%20Import%20Export.png)
+6. **Import/Export** – Export of statistics (CSV/JSON) as well as import/export of URL rules.
+![Admin Menu – Import Export](Impressions/Admin%20Menu%20Import%20Export.png)
 
 ## How it works
 
-Jede Regel definiert:
+Each rule defines:
 
-- einen **URL-Pfad-Matcher**
-- einen **Modus** (_Teilweise_ oder _Vollständig_)
-- Zielwerte (**Base-URL** oder **Ziel-URL**)
+- a **URL path matcher**
+- a **mode** (_partial_ or _complete_)
+- Target values ​​(**Base URL** or **Target URL**)
 
-Der Matcher greift an beliebiger Stelle im Pfad – eine Regel wie `/sites/team`
-matcht sowohl `/sites/team/docs` als auch `/archive/sites/team/docs`.
+The matcher attacks anywhere in the path - a rule like `/sites/team`
+matches both `/sites/team/docs` and `/archive/sites/team/docs`.
 
-**Fallback ohne Regeln:** Bei fehlenden Regeln erfolgt ein Domainersatz gemäß den allgemeinen Einstellungen; Pfad, Parameter und Anker bleiben erhalten.
+**Fallback without rules:** If rules are missing, a domain replacement occurs according to the general settings; Path, parameters and anchors are retained.
 
 ### Rule Modes
 
-| Modus           | Verhalten                                                                                                                                           |
+| Modus           | Behave                                                                                                                                           |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Teilweise**   | Ersetzt Pfadsegmente ab dem Matcher. Base‑URL stammt aus den allgemeinen Einstellungen; zusätzliche Segmente, Parameter und Anker werden angehängt. |
-| **Vollständig** | Leitet komplett auf eine neue Ziel‑URL um. Keine Bestandteile der alten URL werden übernommen.                                                      |
+| **Partially**   | Replaces path segments starting from the matcher. Base URL comes from general settings; additional segments, parameters and anchors are appended. |
+| **Complete** | Completely redirects to a new destination URL. No parts of the old URL are retained.                                                      |
 
-### Gross-/Kleinschreibung
+### Case sensitive
 
-In den allgemeinen Einstellungen kann die Option "Gross/Kleinschreibung beachten" aktiviert werden.
+The “Case sensitive” option can be activated in the general settings.
 
-- **Deaktiviert (Standard):** `/Test` und `/test` werden als gleich behandelt. Das System normalisiert alle Pfade intern zu Kleinbuchstaben.
-- **Aktiviert:** `/Test` und `/test` werden als unterschiedlich betrachtet. Eine Regel für `/Test` greift nicht bei einem Aufruf von `/test`.
+- **Disabled (default):** `/Test` and `/test` are treated as the same. The system internally normalizes all paths to lowercase letters.
+- **Enabled:** `/Test` and `/test` are considered different. A rule for `/Test` does not apply when `/test` is called.
 
-**Best Practice:** Aktivieren Sie diese Option nur, wenn das ursprüngliche System (z. B. ein Linux-Dateisystem oder ein spezifisches CMS) case-sensitive URLs verwendet hat und Sie Kollisionen vermeiden müssen.
+**Best Practice:** Only enable this option if the original system (e.g. a Linux file system or a specific CMS) used case-sensitive URLs and you need to avoid collisions.
 
 ### Examples
 
-**Ausgangs‑URL**
+**Source URL**
 
 ```
 https://intranet.alt.com/sites/team/docs/handbuch.pdf?version=3#kapitel-2
 ```
 
-**Teilweise**
+**Partially**
 
 ```
 Matcher: /sites/team
@@ -127,7 +127,7 @@ Neuer Teilpfad: /teams/finance
 Ergebnis: https://neuesintranet.cloud.com/teams/finance/docs/handbuch.pdf?version=3#kapitel-2
 ```
 
-**Vollständig**
+**Complete**
 
 ```
 Matcher: /sites/team
@@ -135,94 +135,94 @@ Ziel-URL: https://andereseite.com/hub
 Ergebnis: https://andereseite.com/hub
 ```
 
-**Ohne Regel (Domainersatz)**
+**Without rule (domain replacement)**
 
 ```
 Ergebnis: https://neuesintranet.cloud.com/sites/team/docs/handbuch.pdf?version=3#kapitel-2
 ```
 
-### Regelpriorisierung (Spezifität)
+### Rule prioritization (specificity)
 
-Die spezifischste Regel gewinnt. Der Spezifitäts‑Score \(S\) berechnet sich als:
+The most specific rule wins. The specificity score \(S\) is calculated as:
 
 \[
 S = P*{path} \cdot WEIGHT_PATH_SEGMENT + P*{param} \cdot WEIGHT_QUERY_PAIR + W*{wildcards} \cdot PENALTY_WILDCARD + E*{exact} \cdot BONUS_EXACT_MATCH
 \]
 
-- **P_path** – Anzahl exakt übereinstimmender statischer Pfadsegmente
-- **P_param** – Anzahl übereinstimmender Query‑Key=Value‑Paare
-- **W_wildcards** – Wildcards/Platzhalter (werden negativ gewichtet)
-- **E_exact** – Bonus bei kompletter Pfad- und Query‑Übereinstimmung
+- **P_path** – Number of exactly matching static path segments
+- **P_param** – Number of matching query key=value pairs
+- **W_wildcards** – Wildcards/wildcards (are weighted negatively)
+- **E_exact** – Bonus for complete path and query match
 
-Beispiele:
+Examples:
 
-- Request `/subsite/xyz` → Regel `/subsite/xyz` schlägt `/subsite`
-- Request `/subsite?document.aspx=123` → Regel `/subsite?document.aspx=123` schlägt `/subsite`
+- Request `/subsite/xyz` → rule `/subsite/xyz` beats `/subsite`
+- Request `/subsite?document.aspx=123` → Rule `/subsite?document.aspx=123` beats `/subsite`
 
-Tie‑Breaker: mehr statische Segmente → mehr Query‑Paare → weniger Wildcards → älteres `createdAt`/niedrigere ID.
+Tie-breaker: more static segments → more query pairs → fewer wildcards → older `createdAt`/lower ID.
 
-## Erweiterte Regel-Optionen
+## Advanced rule options
 
 ### Smart Search Redirects
-Wenn die Option "Intelligente Such-Weiterleitung" als Fallback aktiviert ist, versucht das System, aus der alten URL einen Suchbegriff zu extrahieren, falls keine direkte Regel greift.
+If the "Intelligent search redirection" option is activated as a fallback, the system tries to extract a search term from the old URL if no direct rule applies.
 
-*   **Standard:** Das letzte Segment des Pfades wird als Suchbegriff verwendet.
-*   **Regex-Regeln:** Sie können spezifische Regeln definieren (z.B. `[?&]file=([^&]+)`), um IDs oder Dokumentennamen aus Parametern zu extrahieren.
-*   **Reihenfolge:** Die Regeln werden von oben nach unten geprüft.
-*   **URL Encoding:** Sie können global oder pro Regel festlegen, ob der extrahierte Suchbegriff URL-kodiert (z.B. `%20` statt Leerzeichen) werden soll.
+*   **Default:** The last segment of the path is used as the search term.
+*   **Regex Rules:** You can define specific rules (e.g. `[?&]file=([^&]+)`) to extract IDs or document names from parameters.
+*   **Order:** Rules are checked from top to bottom.
+*   **URL Encoding:** You can specify globally or per rule whether the extracted search term should be URL encoded (e.g. `%20` instead of spaces).
 
-### Suchen & Ersetzen
+### Find & Replace
 
-Sie können definieren, dass bestimmte Teile der Ziel-URL (inkl. Pfad und Parameter) ersetzt werden sollen. Dies geschieht **nach** der Generierung der Basis-URL, aber **vor** dem Anhängen von statischen Parametern.
+You can define that certain parts of the target URL (including path and parameters) should be replaced. This happens **after** generating the base URL, but **before** appending static parameters.
 
-*   **Suchen:** Der zu ersetzende Text (String).
-*   **Ersetzen:** Der neue Text. Wenn leer, wird der Suchtext gelöscht.
-*   **Case Sensitivity:** Legt fest, ob Groß-/Kleinschreibung beachtet werden soll.
+*   **Find:** The text (string) to replace.
+*   **Replace:** The new text. If empty, the search text is deleted.
+*   **Case Sensitivity:** Determines whether to be case sensitive.
 
 ### Feedback Survey & Fallback
 
-Die Feedback-Umfrage kann optional mit einer **Smart Search Fallback** Funktion erweitert werden. Wenn ein Nutzer "NOK" (Daumen runter) klickt und die intelligente Such-Weiterleitung aktiv ist, wird ihm ein alternativer Such-Link angeboten.
+The feedback survey can optionally be expanded with a **Smart Search Fallback** function. If a user clicks "NOK" (thumbs down) and intelligent search redirection is active, they will be offered an alternative search link.
 
-*   Dies erzeugt einen separaten Statistik-Eintrag.
-*   Der Nutzer kann auch für diesen Vorschlag Feedback geben.
-*   Klickt der Nutzer erneut "NOK", kann er (falls aktiviert) die korrekte URL vorschlagen.
+*   This creates a separate statistics entry.
+*   The user can also provide feedback for this suggestion.
+*   If the user clicks "NOK" again, he can (if activated) suggest the correct URL.
 
-**Hinweis zu Auto-Redirect:**
-Wenn Auto-Redirect (global oder per Regel) aktiviert ist, wird die Feedback-Umfrage übersprungen. Das System loggt diese Interaktion automatisch als `auto-redirect` in der Feedback-Statistik.
+**Note about auto-redirect:**
+If auto-redirect is enabled (globally or by rule), the feedback survey will be skipped. The system automatically logs this interaction as “auto-redirect” in the feedback statistics.
 
 ### Parameter-Handling
 
-Bei "Teilweise" (Partial) und "Vollständig" (Wildcard) Redirects können Sie steuern, wie mit URL-Parametern verfahren wird.
+For "Partial" and "Full" (Wildcard) redirects, you can control how URL parameters are handled.
 
-**Für Partial & Domain Regeln:**
-1.  **Parameter verwerfen (Discard):** Aktivieren Sie "Alle Link-Parameter entfernen", um standardmäßig alle Query-Parameter der alten URL zu löschen. Wenn deaktiviert, werden alle Parameter übernommen.
-2.  **Ausnahmen definieren (Keep):** Wenn Discard aktiviert ist, können Sie spezifische Parameter definieren, die trotzdem beibehalten werden sollen.
+**For Partial & Domain Rules:**
+1. **Discard parameters:** Check "Remove all link parameters" to delete all query parameters of the old URL by default. If disabled, all parameters are applied.
+2. **Define Exceptions (Keep):** If Discard is enabled, you can define specific parameters that should still be retained.
 
-**Für Wildcard Regeln:**
-1.  **Parameter behalten (Forward):** Aktivieren Sie "Alle Link-Parameter beibehalten", um alle Parameter 1:1 an die Ziel-URL anzuhängen.
-2.  **Spezifische Parameter:** Wenn Forward deaktiviert ist, werden standardmäßig alle Parameter entfernt. Sie können dann unter "Parameter beibehalten / umbenennen" spezifische Ausnahmen definieren.
+**For Wildcard Rules:**
+1. **Keep parameters (Forward):** Check "Keep all link parameters" to append all parameters 1:1 to the target URL.
+2. **Specific Parameters:** When Forward is disabled, all parameters are removed by default. You can then define specific exceptions under "Keep/rename parameters".
 
-**Allgemein:**
-*   **Regex:** Key und Value können per Regex definiert werden.
-*   **Umbenennen:** Sie können einen "Ziel-Key" angeben. Beispiel: Aus `?file=dokument.pdf` wird `?f=dokument.pdf`.
-*   **Nicht kodieren (Raw):** Für statische und beibehaltene Parameter kann die Option "Nicht kodieren" aktiviert werden. Dies verhindert die standardmäßige URL-Kodierung der Werte (nützlich, wenn `%20` statt `+` benötigt wird oder der Wert bereits kodiert vorliegt).
-*   **Statische Parameter:** Sie können Parameter definieren, die **immer** angehängt werden (z.B. `?source=migration`).
+**Generally:**
+*   **Regex:** Key and Value can be defined via Regex.
+*   **Rename:** You can specify a "Target Key". Example: `?file=document.pdf` becomes `?f=document.pdf`.
+*   **Do Not Encode (Raw):** For static and persisted parameters, the Do Not Encode option can be enabled. This prevents the default URL encoding of the values ​​(useful if `%20` is needed instead of `+` or the value is already encoded).
+*   **Static parameters:** You can define parameters that will **always** be appended (e.g. `?source=migration`).
 
-**Reihenfolge der Parameter in der Ziel-URL:**
-1.  Statische Parameter (in der definierten Reihenfolge)
-2.  Behaltene Parameter (in der definierten Reihenfolge)
+**Order of parameters in the target URL:**
+1. Static parameters (in the defined order)
+2. Retained parameters (in the defined order)
 
-**Beispiel:**
+**Example:**
 *   Alte URL: `.../page?old=123&ignore=me`
-*   Statisch: `new=A`
+*   Static: `new=A`
 *   Keep: `old` -> `id`
-*   Ergebnis: `.../ziel?new=A&id=123`
+*   Result: `.../target?new=A&id=123`
 
 ## Use Cases
 
 - Migrationen (z. B. SharePoint On‑Premises → SharePoint Online)
-- Domain‑Rebrands und Konsolidierungen
-- Umstrukturierungen großer Linklandschaften
+- Domain rebrands and consolidations
+- Restructuring of large link landscapes
 
 ## Quick Start
 
@@ -230,29 +230,29 @@ Bei "Teilweise" (Partial) und "Vollständig" (Wildcard) Redirects können Sie st
 
 - Node.js >= 22
 
-Überprüfen Sie die Installation:
+Check the installation:
 
 ```bash
 node --version
 npm --version
 ```
 
-### 1. Repository klonen
+### 1. Clone repository
 
 ```bash
 git clone <repository-url>
 cd SmartRedirectSuite
 ```
 
-### 2. Dependencies installieren
+### 2. Install dependencies
 
 ```bash
 npm install
 ```
 
-### 3. .env-Datei erstellen
+### 3. Create .env file
 
-Erstellen Sie eine `.env` Datei im Hauptverzeichnis:
+Create a `.env` file in the root directory:
 
 ```bash
 cat > .env <<'EOF'
@@ -280,7 +280,7 @@ NODE_ENV=development
 EOF
 ```
 
-### 4. Anwendung starten
+### 4. Start the application
 
 ```bash
 npm run dev        # Entwicklungsmodus
@@ -289,17 +289,17 @@ npm run build
 npm start          # Produktion
 ```
 
-Die Anwendung läuft anschließend unter `http://localhost:5000`.
+The application then runs at `http://localhost:5000`.
 
-## Öffentliche API
+## Public API
 
-Die SmartRedirect Suite bietet einen öffentlichen API-Endpunkt zur Automatisierung von URL-Transformationen. Dieser Endpunkt erfordert keine Authentifizierung und wendet das konfigurierte Rate-Limiting an.
+The SmartRedirect Suite provides a public API endpoint for automating URL transformations. This endpoint does not require authentication and applies the configured rate limiting.
 
 ### URL-Transformation Endpoint
 
 `POST /api/public/transform`
 
-Mit diesem Endpoint können Sie eine alte URL übergeben und erhalten die entsprechende neue URL gemäß den konfigurierten Weiterleitungsregeln zurück. Die URL kann entweder als JSON-Body oder als Query-Parameter übergeben werden.
+This endpoint allows you to pass an old URL and receive the corresponding new URL back according to the configured redirect rules. The URL can be passed either as a JSON body or as a query parameter.
 
 **Request Body (JSON)**
 
@@ -325,19 +325,19 @@ Mit diesem Endpoint können Sie eine alte URL übergeben und erhalten die entspr
 }
 ```
 
-- `oldUrl`: Die ursprüngliche URL.
-- `newUrl`: Die generierte Ziel-URL.
-- `hasMatch`: `true`, wenn eine spezifische Regel angewendet wurde, ansonsten `false`.
-- `ruleId`: Die UUID der angewendeten Regel (falls vorhanden).
-- `redirectStrategy`: Der angewendete Weiterleitungsmodus (z.B. `rule`, `domain-fallback`, `smart-search`).
+- `oldUrl`: The original URL.
+- `newUrl`: The generated target URL.
+- `hasMatch`: `true` if a specific rule was applied, `false` otherwise.
+- `ruleId`: The UUID of the applied rule (if any).
+- `redirectStrategy`: The redirect mode applied (e.g. `rule`, `domain-fallback`, `smart-search`).
 
 ## Administration
 
-Der Admin-Bereich lässt sich über das Zahnrad-Symbol oben rechts oder direkt über den URL-Parameter `?admin=true` öffnen.
+The admin area can be opened via the gear symbol in the top right or directly via the URL parameter `?admin=true`.
 
-### Regeln importieren
+### Import rules
 
-Beispiel einer JSON-Datei:
+Example of a JSON file:
 
 ```json
 {
@@ -352,140 +352,140 @@ Beispiel einer JSON-Datei:
 }
 ```
 
-Im Admin-Panel hochladen oder über `sample-rules-import.json` einsehen.
+Upload in the admin panel or view via `sample-rules-import.json`.
 
-### Einstellungen anpassen
+### Adjust settings
 
-Im Admin-Panel können Texte, Farben und UI-Elemente angepasst werden, einschließlich:
+In the admin panel, texts, colors and UI elements can be customized, including:
 
 - Header und Icons
 - Popup-Texte
-- Labels im URL-Vergleich
-- Sichtbarkeit der Buttons ("URL kopieren" und "In neuem Tab öffnen")
-- Klickverhalten der angezeigten URL (Kopieren, Öffnen, oder Keine Aktion)
-- Button-Beschriftungen
-- Zusätzliche Info-Bereiche
+- Labels in URL comparison
+- Visibility of the buttons (“Copy URL” and “Open in new tab”)
+- Click behavior of the displayed URL (copy, open, or no action)
+- Button labels
+- Additional info areas
 
 ### Matching Indicator
 
-Der Matching Indicator (Link-Qualitätstacho) visualisiert, wie gut eine aufgerufene URL zu einer neuen URL passt. Er wird auf der Migrationsseite angezeigt.
+The matching indicator (link quality tachometer) visualizes how well a visited URL matches a new URL. It will appear on the migration page.
 
-**Qualitätsstufen:**
+**Quality levels:**
 
-- **Grün (100%):** Exakte Übereinstimmung oder Startseite (Root).
-- **Gelb (60-90%):** URL erkannt, aber mit leichten Abweichungen (z.B. zusätzliche Parameter).
-- **Rot (< 60%):** Nur Teilübereinstimmung (Partial Match) oder keine spezifische Zuordnung möglich.
+- **Green (100%):** Exact match or home page (root).
+- **Yellow (60-90%):** URL recognized, but with slight deviations (e.g. additional parameters).
+- **Red (< 60%):** Only partial match or no specific assignment possible.
 
-Die Erklärungstexte für diese Stufen können im Admin-Bereich unter "Allgemeine Einstellungen" individuell angepasst werden.
+The explanatory texts for these levels can be customized in the admin area under “General Settings”.
 
-### Statistiken & Monitoring
+### Statistics & Monitoring
 
-Das Admin-Panel zeigt:
+The admin panel shows:
 
-- Zugriffszahlen (gesamt, heute, Woche)
+- Access numbers (total, today, week)
 - Top-URLs
-- Zeitbasierte Auswertungen (24h, 7 Tage, alle Daten)
-- Export als CSV/JSON
+- Time-based evaluations (24h, 7 days, all data)
+- Export as CSV/JSON
 
-### Performance & Systemanforderungen
+### Performance & System Requirements
 
-Das System verwendet eine hochoptimierte In-Memory-Verarbeitung für URL-Regeln und Tracking-Daten.
+The system uses highly optimized in-memory processing for URL rules and tracking data.
 
-*   **Tracking-Cache:** Um hohe I/O-Lasten zu vermeiden, können Tracking-Daten im Arbeitsspeicher gehalten werden. Dies ist standardmäßig aktiviert und beschleunigt Dashboard-Zugriffe massiv.
-    *   **Empfehlung:** Für Produktionssysteme mit vielen Zugriffen sollten mindestens **512 MB bis 1 GB RAM** eingeplant werden, insbesondere wenn die Anzahl der Tracking-Einträge 500'000 übersteigt.
-    *   **Konfiguration:** Der Cache kann in den Admin-Einstellungen unter "System & Daten" -> "Systemeinstellungen" deaktiviert werden, falls der Arbeitsspeicher knapp ist (führt zu langsameren Statistiken).
+*   **Tracking cache:** To avoid high I/O loads, tracking data can be kept in memory. This is enabled by default and massively speeds up dashboard access.
+    *   **Recommendation:** For production systems with a lot of access, at least **512 MB to 1 GB RAM** should be planned, especially if the number of tracking entries exceeds 500,000.
+    *   **Configuration:** The cache can be disabled in the admin settings under "System & Data" -> "System Settings" if RAM is low (results in slower statistics).
 
-## Release Prozess
+## Release process
 
-Dieses Projekt verwendet eine automatisierte CI/CD-Pipeline mit **GitHub Actions** und **Semantic Release**.
+This project uses an automated CI/CD pipeline with **GitHub Actions** and **Semantic Release**.
 
-- Commits sollten der [Conventional Commits](https://www.conventionalcommits.org/) Konvention folgen (z.B. `feat:`, `fix:`).
-- Bei einem Push auf `main` wird automatisch getestet, versioniert und veröffentlicht.
-- Docker-Images werden automatisch in die GitHub Container Registry (ghcr.io) gepusht.
+- Commits should follow the [Conventional Commits](https://www.conventionalcommits.org/) convention (e.g. `feat:`, `fix:`).
+- When pushed to `main`, testing, versioning and publishing are carried out automatically.
+- Docker images are automatically pushed to the GitHub Container Registry (ghcr.io).
 
-Weitere Details finden Sie in der [Release-Documentation](./docs/release-pipeline.md).
+Further details can be found in the [Release Documentation](./docs/release-pipeline.md).
 
-## Validierung & Qualitätssicherung
+## Validation & Quality Assurance
 
-Die Anwendung verhindert:
+The application prevents:
 
-- Doppelte URL-Matcher
-- Überlappende Regeln (z. B. `/news/` und `/news/archive/`)
-- Wildcard-Konflikte
-- Ungültige Pfadsegmente
+- Duplicate URL matchers
+- Overlapping rules (e.g. `/news/` and `/news/archive/`)
+- Wildcard conflicts
+- Invalid path segments
 
-Fehler werden detailliert auf Deutsch ausgegeben; bei Validierungsfehlern werden keine Änderungen gespeichert.
+Errors are reported in detail in German; If there are validation errors, no changes are saved.
 
-## Datenverwaltung
+## Data management
 
-Standardmäßig werden JSON-Dateien im `data/` Verzeichnis genutzt:
+By default, JSON files in the `data/` directory are used:
 
 - `data/rules.json`, `data/settings.json`, `data/tracking.json`
-- `data/sessions/` für Admin-Sessions
+- `data/sessions/` for admin sessions
 
-## Sicherheit
+## Security
 
-- Persistente Session-Authentifizierung (7 Tage)
-- Sichere Cookies und dateibasierte Sessions
-- Passwortgeschützter Admin-Bereich
-- Brute-Force-Schutz mit IP-Sperre (konfigurierbar über `LOGIN_MAX_ATTEMPTS` und `LOGIN_BLOCK_DURATION_MS`)
-- XSS-Schutz durch React
-- Input-Validierung mit Zod
-- Konfiguration über Umgebungsvariablen
+- Persistent session authentication (7 days)
+- Secure cookies and file-based sessions
+- Password protected admin area
+- Brute force protection with IP blocking (configurable via `LOGIN_MAX_ATTEMPTS` and `LOGIN_BLOCK_DURATION_MS`)
+- XSS protection through React
+- Input validation with Zod
+- Configuration via environment variables
 
 ## Deployment
 
-Die App verwendet standardmäßig SQLite als Datenbank, kann jedoch auch mit PostgreSQL oder MariaDB/MySQL betrieben werden. Weitere Informationen finden Sie in der [Docker Deployment Documentation](./docs/DOCKER_DEPLOYMENT.md) und in den mitgelieferten docker-compose Beispielen.
+The app uses SQLite as the database by default, but can also be operated with PostgreSQL or MariaDB/MySQL. For more information, see the [Docker Deployment Documentation](./docs/DOCKER_DEPLOYMENT.md) and the included docker-compose examples.
 
 
-Lokale Produktion:
+Local Production:
 
 ```bash
 npm run build
 npm start
 ```
 
-Weitere Plattformen: Vercel, Heroku oder Docker. Details zur Docker-Installation finden Sie im [Docker Deployment Guide](./docs/DOCKER_DEPLOYMENT.md).
+Other platforms: Vercel, Heroku or Docker. For Docker installation details, see the [Docker Deployment Guide](./docs/DOCKER_DEPLOYMENT.md).
 
-Für Demo-Zwecke mit täglichem Reset der Daten kann das `Dockerfile.demo` genutzt werden (setzt Sessions, Uploads und Einstellungen täglich zurück).
+For demo purposes with daily data reset, the `Dockerfile.demo` can be used (resets sessions, uploads and settings daily).
 
-### Automatisches Deployment auf fly.io
+### Automatic deployment on fly.io
 
-Das Repository enthält eine CI/CD-Pipeline (`.github/workflows/deploy.yml`) für das automatische Deployment auf fly.io.
+The repository contains a CI/CD pipeline (`.github/workflows/deploy.yml`) for automatic deployment to fly.io.
 
-*   **Trigger:** Ein Push auf den Branch `NextRelease` löst das Deployment aus.
-*   **Voraussetzungen:**
-    *   Das Secret `FLY_API_TOKEN` muss in den GitHub Repository Settings hinterlegt sein.
-    *   Die Konfiguration erfolgt über die `fly.toml` und das `Dockerfile.demo`.
-*   **Ablauf:** Die GitHub Action authentifiziert sich via Token, baut das Image remote auf fly.io und deployt die neue Version.
+*   **Trigger:** A push to the `NextRelease` branch triggers the deployment.
+*   **Requirements:**
+    *   The secret `FLY_API_TOKEN` must be stored in the GitHub Repository Settings.
+    *   The configuration is done via the `fly.toml` and the `Dockerfile.demo`.
+*   **Process:** The GitHub Action authenticates itself via token, builds the image remotely on fly.io and deploys the new version.
 
-## Entwicklung
+## Development
 
-Technologie-Stack:
+Technology-Stack:
 
 - React 18, TypeScript, Vite, Tailwind CSS, shadcn/ui
-- Express.js und Zod im Backend
+- Express.js and Zod in the backend
 - TanStack Query, Wouter, React Hook Form
 
-Richtlinien:
+Guidelines:
 
-1. TypeScript verwenden
-2. Zod-Schemas zur Validierung
-3. Shared Types zwischen Frontend und Backend
-4. UI in deutscher Sprache
+1. Use TypeScript
+2. Zod schemas for validation
+3. Shared Types between Frontend and Backend
+4. UI in German
 5. Responsive, Mobile-First Design
 
-Branding & Versionierung:
+Branding & Versioning:
 
-- App-Name und Version werden zentral über `shared/appMetadata.ts` aus der `package.json` abgeleitet.
-- Änderungen an Name/Version müssen nur dort erfolgen und stehen danach sowohl im Client (Dokumenttitel, Footer) als auch im Server (Response-Header) zur Verfügung.
+- App name and version are derived centrally from the `package.json` via `shared/appMetadata.ts`.
+- Changes to the name/version only have to be made there and are then available both in the client (document title, footer) and in the server (response header).
 
-## Support & Beitrag
+## Support & Contribution
 
-Bei Problemen:
+In case of problems:
 
-1. Konsolen-Logs prüfen
-2. Umgebungsvariablen kontrollieren
-3. Dependencies installieren
-4. `ADMIN_PASSWORD` verifizieren
-5. Upload-Pfad bei Logo-Fehlern prüfen
+1. Check console logs
+2. Control environmental variables
+3. Install dependencies
+4. Verify `ADMIN_PASSWORD`
+5. Check upload path in case of logo errors

--- a/docs/ADMIN_DOCUMENTATION.md
+++ b/docs/ADMIN_DOCUMENTATION.md
@@ -1,66 +1,66 @@
 # SmartRedirect Suite - Admin-Dokumentation
 
-Diese Dokumentation richtet sich an Administratoren und DevOps-Teams. Sie bündelt Ressourcen für Installation, Deployment und den laufenden Betrieb.
+This documentation is intended for administrators and DevOps teams. It bundles resources for installation, deployment and ongoing operations.
 
-Der Admin-Bereich ist über das Zahnrad-Symbol der Anwendung oder durch Anhängen von `?admin=true` an die Basis-URL erreichbar.
+The admin area is accessible via the application's gear icon or by appending `?admin=true` to the base URL.
 
-## Installations- und Deployment-Ressourcen
-- [INSTALLATION.md](./INSTALLATION.md): Schnellstart für lokale Entwicklung.
-- [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md): Leitfaden für Produktionsumgebungen.
-- [OPENSHIFT_DEPLOYMENT.md](./OPENSHIFT_DEPLOYMENT.md): Beispielkonfiguration für OpenShift.
-- [API_DOCUMENTATION.md](./API_DOCUMENTATION.md): REST-API für Automatisierung und Monitoring.
-- `Dockerfile.demo`: Demo-Container mit automatischem 24h-Reset für Tests.
+## Installation and deployment resources
+- [INSTALLATION.md](./INSTALLATION.md): Quick start for local development.
+- [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md): Guide for production environments.
+- [OPENSHIFT_DEPLOYMENT.md](./OPENSHIFT_DEPLOYMENT.md): Example configuration for OpenShift.
+- [API_DOCUMENTATION.md](./API_DOCUMENTATION.md): REST API for automation and monitoring.
+- `Dockerfile.demo`: Demo container with automatic 24h reset for tests.
 
-## Benutzeroberfläche
-- **Tabellen-Resizing**: In der "Regeln"-Ansicht und der "Import-Vorschau" können Spaltenbreiten individuell angepasst werden. Bewegen Sie dazu die Maus an den rechten Rand einer Spaltenüberschrift, bis der Cursor sich ändert, und ziehen Sie die Spalte auf die gewünschte Breite.
+## User Interface
+- **Table resizing**: Column widths can be adjusted individually in the "Rules" view and the "Import preview". To do this, move the mouse to the right edge of a column heading until the cursor changes and drag the column to the desired width.
 
-## Wartung
-- Regelmäßige Backups der `data/`-Verzeichnisse.
-- Abgelaufene Sessions unter `data/sessions/` bereinigen.
-- Logs und Performance-Metriken gemäß Deployment-Guides überwachen.
-- **Cache neu aufbauen**: Im Admin-Bereich unter "System & Daten" > "Wartung" kann der Regel-Cache manuell neu aufgebaut werden. Dies ist normalerweise nicht erforderlich, kann aber helfen, wenn nach umfangreichen Importen oder Updates Probleme mit Weiterleitungen auftreten.
+## Maintenance
+- Regular backups of the `data/` directories.
+- Clean up expired sessions under `data/sessions/`.
+- Monitor logs and performance metrics according to deployment guides.
+- **Rebuild cache**: The rule cache can be rebuilt manually in the admin area under "System & Data" > "Maintenance". This isn't usually necessary, but can help if you're having redirect issues after large imports or updates.
 
 ## Referrer Tracking & Analytics
-- Das System erfasst automatisch den HTTP Referrer (Herkunftsseite) für jeden Zugriff.
-- **Top 10 Referrer**: Ein Dashboard-Widget zeigt die häufigsten Herkunfts-Domains an.
-- **Direct Access**: Wenn kein Referrer vorhanden ist (z.B. direkter Aufruf oder Lesezeichen), wird dies als "-" oder "Direct" angezeigt.
-- **Datenexport**: Der CSV-Export der Statistiken enthält nun eine "Referrer"-Spalte mit der vollständigen URL.
+- The system automatically records the HTTP referrer (source page) for each access.
+- **Top 10 Referrers**: A dashboard widget displays the most common source domains.
+- **Direct Access**: If there is no referrer (e.g. direct access or bookmark), this is displayed as "-" or "Direct".
+- **Data export**: The CSV export of statistics now contains a "Referrer" column with the full URL.
 
-## Login-Schutz
-- Fehlgeschlagene Anmeldungen werden IP-basiert gezählt.
-- Nach `LOGIN_MAX_ATTEMPTS` Fehlversuchen (Standard: 5) wird die IP für `LOGIN_BLOCK_DURATION_MS` Millisekunden (Standard: 24h) gesperrt.
-- Werte können über Umgebungsvariablen in der `.env` angepasst werden.
-- **Sperren aufheben**: Im Admin-Bereich unter "System & Daten" > "Danger-Zone" können alle aktuell blockierten IP-Adressen über den Button "Blockierte IPs löschen" manuell entsperrt werden. Dies ermöglicht den Nutzern sofortigen erneuten Zugriff.
+## Login protection
+- Failed logins are counted based on IP.
+- After `LOGIN_MAX_ATTEMPTS` failed attempts (default: 5), the IP is blocked for `LOGIN_BLOCK_DURATION_MS` milliseconds (default: 24h).
+- Values ​​can be adjusted via environment variables in the `.env`.
+- **Unblock**: In the admin area under "System & Data" > "Danger Zone", all currently blocked IP addresses can be manually unblocked using the "Delete blocked IPs" button. This allows users immediate re-access.
 
-## Regelpriorisierung & Debugging
-- Gewichtungen und Normalisierung befinden sich in `shared/constants.ts` (`RULE_MATCHING_CONFIG`).
-- Aktivieren Sie `DEBUG` in dieser Konfiguration, um pro Anfrage Score, angewandte Tie‑Breaker und die gewählte Regel zu protokollieren.
-- Die Groß-/Kleinschreibung der Link-Erkennung lässt sich im Admin-Tab „Einstellungen → Link-Erkennung“ über den Schalter "Groß-/Kleinschreibung beachten" steuern (Standard: aus).
+## Rule prioritization & debugging
+- Weights and normalization are in `shared/constants.ts` (`RULE_MATCHING_CONFIG`).
+- Enable `DEBUG` in this configuration to log score, applied tie-breakers and the chosen rule per request.
+- The case sensitivity of link detection can be controlled in the admin tab “Settings → Link detection” using the “Case sensitive” switch (default: off).
 
-## Domain-Regeln
-Neben den klassischen Pfad-Regeln werden auch Domain-Regeln unterstützt.
+## Domain Rules
+In addition to the classic path rules, domain rules are also supported.
 
 ### Matcher
-Der Matcher kann nun entweder ein Pfad (beginnend mit `/`) oder eine Domain sein (z.B. `www.google.ch`).
-- **Pfad-Matcher**: `/news` matcht auf `http://anydomain.com/news`.
-- **Domain-Matcher**: `www.google.ch` matcht auf `http://www.google.ch/any/path`.
+The matcher can now be either a path (starting with `/`) or a domain (e.g. `www.google.ch`).
+- **Path Matcher**: `/news` matches `http://anydomain.com/news`.
+- **Domain Matcher**: `www.google.ch` matches `http://www.google.ch/any/path`.
 
-### Redirect Typ: Domain-Ersatz
-Der Typ "Domain-Ersatz" (`domain`) ermöglicht flexible Weiterleitungen:
-1. **Pfad-Erhalt**: Der ursprüngliche Pfad und alle Query-Parameter bleiben erhalten. Es wird lediglich die Domain ausgetauscht.
-2. **Kombination mit Pfad-Matchern**: Wenn ein Pfad-Matcher (z.B. `/altes-verzeichnis`) verwendet wird, aber der Typ `domain` gewählt ist, wird der Matcher im Pfad ignoriert und der gesamte ursprüngliche Pfad an die neue Domain angehängt (analog zu einer Wildcard-Domain-Weiterleitung für diesen speziellen Pfad).
-3. **Domain-Matcher**: Wenn der Matcher eine Domain ist (z.B. `old-site.com`), werden alle Anfragen an diese Domain auf die `Target URL` umgeleitet, wobei der Pfad erhalten bleibt.
+### Redirect Type: Domain replacement
+The “domain replacement” type (`domain`) allows flexible redirects:
+1. **Path Preservation**: The original path and all query parameters are preserved. Only the domain is exchanged.
+2. **Combination with path matchers**: If a path matcher (e.g. `/old-directory`) is used but the `domain` type is selected, the matcher in the path is ignored and the entire original path is appended to the new domain (analogous to a wildcard domain redirect for that specific path).
+3. **Domain Matcher**: If the matcher is a domain (e.g. `old-site.com`), all requests to that domain will be redirected to the `Target URL`, preserving the path.
 
-Dies ermöglicht komplexe Migrationsszenarien, bei denen ganze Domains oder Subdomains umgezogen werden, ohne für jeden Pfad eine eigene Regel erstellen zu müssen.
+This enables complex migration scenarios where entire domains or subdomains are moved without having to create a separate rule for each path.
 
-## Konfigurationsvalidierung
-Ein Werkzeug zum Testen von Weiterleitungsregeln, ohne sie live auszuführen.
+## Configuration validation
+A tool for testing redirect rules without running them live.
 
-### Funktionen
-- **Bulk-Validierung**: Testen Sie bis zu 1000 URLs auf einmal durch Einfügen (Copy & Paste) oder Datei-Import (CSV, Excel).
-- **Trace-View**: Detaillierte Nachverfolgung jedes Verarbeitungsschritts (Regel-Anwendung, Globale Suchen & Ersetzen, Query-Parameter-Logik).
-- **Änderungsverfolgung**: Visualisierung von Änderungen mit Farbcodierung (Regeln vs. Globale Einstellungen) und Durchstreichung alter Werte.
-- **CSV-Export**: Exportieren Sie die Ergebnisse inklusive aller Trace-Details für die Dokumentation oder Analyse.
-- **Workflow**: Direkter Link zum Bearbeiten von Regeln aus der Ergebnisliste heraus. Nach dem Speichern von Änderungen kann die Validierung mit einem Klick aktualisiert werden.
+### Features
+- **Bulk Validation**: Test up to 1000 URLs at once by pasting (copy & paste) or file import (CSV, Excel).
+- **Trace View**: Detailed tracking of each processing step (rule application, global search & replace, query parameter logic).
+- **Change Tracking**: Visualize changes with color coding (Rules vs. Global Settings) and crossing out old values.
+- **CSV export**: Export the results including all trace details for documentation or analysis.
+- **Workflow**: Direct link to edit rules from the results list. After saving changes, the validation can be updated with one click.
 
-Zu finden im Tab "Regeln" über den Button "Konfigurationsvalidierung" (Nur für authentifizierte Administratoren verfügbar).
+Can be found in the “Rules” tab via the “Configuration Validation” button (only available for authenticated administrators).

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -1,11 +1,11 @@
 # SmartRedirect Suite - Enterprise API Documentation
 
-> **Overview**: Diese API-Dokumentation beschreibt alle verfügbaren REST-Endpunkte für die URL-Migration-Anwendung. Für Installation siehe [INSTALLATION.md](./INSTALLATION.md), für vollständige Feature-Informationen [README.md](../README.md).
+> **Overview**: This API documentation describes all available REST endpoints for the URL Migration application. For installation see [INSTALLATION.md](./INSTALLATION.md), for full feature information see [README.md](../README.md).
 
-## 📚 Verwandte Dokumentation
+## 📚 Related documentation
 
-- **[README.md](../README.md)**: Vollständige Anwendungsdokumentation mit allen Features
-- **[INSTALLATION.md](./INSTALLATION.md)**: Schnellstart-Anleitung für Entwicklung
+- **[README.md](../README.md)**: Complete application documentation with all features
+- **[INSTALLATION.md](./INSTALLATION.md)**: Quick start guide for development
 - **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: Production-Deployment und Monitoring
 
 ## Overview

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,16 +1,16 @@
 # SmartRedirect Suite - Architektur-Overview
 
-Die Anwendung ist modular aufgebaut und trennt klar zwischen Frontend, Backend und gemeinsam genutzten Typen.
+The application has a modular structure and clearly separates frontend, backend and shared types.
 
-## Komponenten
-- **client/**: React 18 + TypeScript Frontend, gebündelt mit Vite.
-- **server/**: Express-basiertes Backend mit Dateispeicher und Session-Handling.
-- **shared/**: Gemeinsame TypeScript-Typen und Validierungsschemata.
+## Components
+- **client/**: React 18 + TypeScript frontend, bundled with Vite.
+- **server/**: Express-based backend with file storage and session handling.
+- **shared/**: Shared TypeScript types and validation schemes.
 
-## Ablauf
-1. Anfragen erreichen das `server/`-Modul.
-2. Der Server prüft Regeln gegen einen **In-Memory Cache**, der beim Start aus `data/rules.json` geladen wird, um I/O-Latenz zu vermeiden.
-3. Validierte Daten werden an das `client/`-Frontend ausgeliefert.
-4. `shared/` stellt Typdefinitionen und Zod-Schemas für beide Seiten bereit.
+## Process
+1. Requests reach the `server/` module.
+2. The server checks rules against an **in-memory cache** loaded from `data/rules.json` at startup to avoid I/O latency.
+3. Validated data is delivered to the `client/` frontend.
+4. `shared/` provides type definitions and Zod schemas for both sides.
 
-Die Architektur ermöglicht die hochperformante Verarbeitung von über 100.000 Regeln durch intelligentes Caching und optimierte Datenstrukturen.
+The architecture enables high-performance processing of over 100,000 rules through intelligent caching and optimized data structures.

--- a/docs/CONFIGURATION_EXAMPLES.md
+++ b/docs/CONFIGURATION_EXAMPLES.md
@@ -1,6 +1,6 @@
 # SmartRedirect Suite - Konfigurationsbeispiele
 
-## .env Beispiel
+## .env example
 ```bash
 ADMIN_PASSWORD=MeinSicheresPasswort123
 SESSION_SECRET=super-geheimer-session-schluessel-hier-einfuegen-mindestens-32-zeichen
@@ -10,8 +10,8 @@ PORT=5000
 NODE_ENV=development
 ```
 
-## Beispiel-Regeln
-Die Datei [sample-rules-import.json](../sample-rules-import.json) zeigt den Aufbau einer Regeldatei:
+## Example rules
+The file [sample-rules-import.json](../sample-rules-import.json) shows the structure of a rules file:
 
 ```json
 {
@@ -26,42 +26,42 @@ Die Datei [sample-rules-import.json](../sample-rules-import.json) zeigt den Aufb
 }
 ```
 
-## Parameter beibehalten (Keep Query Params) mit Regex
+## Keep Query Params with Regex
 
-Die Funktion "Parameter beibehalten" erlaubt es, spezifische Query-Parameter aus der alten URL zu übernehmen und optional zu transformieren.
+The "Keep parameters" function allows specific query parameters to be taken over from the old URL and optionally transformed.
 
-### Beispiel 1: Einfaches Beibehalten
-Behält den Parameter `ref` bei.
+### Example 1: Simple Preserve
+Preserves the `ref` parameter.
 
 - **Parameter Key (Regex):** `ref`
-- **Value Matcher:** (leer)
-- **Neuer Name:** (leer)
+- **Value Matcher:** (leather)
+- **New name:** (empty)
 
-**Ergebnis:** `/old?ref=123` -> `/new?ref=123`
+**Result:** `/old?ref=123` -> `/new?ref=123`
 
-### Beispiel 2: Umbenennen
-Benennt den Parameter `utm_source` in `source` um.
+### Example 2: Rename
+Renames the `utm_source` parameter to `source`.
 
 - **Parameter Key (Regex):** `utm_source`
-- **Value Matcher:** (leer)
-- **Neuer Name:** `source`
+- **Value Matcher:** (leather)
+- **New name:** `source`
 
-**Ergebnis:** `/old?utm_source=google` -> `/new?source=google`
+**Result:** `/old?utm_source=google` -> `/new?source=google`
 
-### Beispiel 3: Wert extrahieren mit Regex (Lookbehind)
-Extrahiert einen Teil des Wertes, der nach einem Backslash steht (z.B. Domain-User).
+### Example 3: Extract value with regex (lookbehind)
+Extracts a part of the value that comes after a backslash (e.g. Domain-User).
 
 - **Parameter Key (Regex):** `accountname`
 - **Value Matcher (Regex):** `(?<=\\).*`
-- **Neuer Name:** `user`
+- **New name:** `user`
 
-**Ergebnis:** `/old?accountname=DOMAIN\User123` -> `/new?user=User123`
+**Result:** `/old?accountname=DOMAIN\User123` -> `/new?user=User123`
 
-### Beispiel 4: Wert extrahieren mit Capture Group
-Extrahiert die ID aus einem komplexen String.
+### Example 4: Extract value with Capture Group
+Extracts the ID from a complex string.
 
 - **Parameter Key (Regex):** `id`
 - **Value Matcher (Regex):** `^prefix-(\d+)$`
-- **Neuer Name:** `itemId`
+- **New name:** `itemId`
 
 **Ergebnis:** `/old?id=prefix-555` -> `/new?itemId=555`

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -1,16 +1,16 @@
 # Docker Deployment Guide - SmartRedirect Suite
 
-Diese Anleitung erklärt, wie die SmartRedirect Suite mittels Docker bereitgestellt wird. Sie deckt das Beziehen des Images, das Bauen aus dem Quellcode, die Konfiguration, Datenpersistenz und die Verwendung von Docker Compose für Produktionsumgebungen ab.
+This guide explains how to deploy the SmartRedirect Suite using Docker. It covers obtaining the image, building from source, configuration, data persistence, and using Docker Compose for production environments.
 
-## 🚀 Schnellstart (Image beziehen)
+## 🚀 Quick start (get image)
 
-Das Docker Image kann direkt aus der GitHub Container Registry bezogen werden. Um die aktuellste Version zu erhalten:
+The Docker image can be obtained directly from the GitHub Container Registry. To get the latest version:
 
 ```bash
 docker pull ghcr.io/drunkenhusky/smartredirectsuite:latest
 ```
 
-Starten Sie einen Container (Demo-Modus):
+Start a container (demo mode):
 
 ```bash
 docker run -d \
@@ -21,11 +21,11 @@ docker run -d \
   ghcr.io/drunkenhusky/smartredirectsuite:latest
 ```
 
-Die Anwendung ist anschließend unter `http://localhost:5000` erreichbar.
+The application can then be accessed at `http://localhost:5000`.
 
-## 🏗️ Image bauen (Aus Quellcode)
+## 🏗️ Build Image (From Source Code)
 
-Wenn Sie das Image selbst bauen möchten, müssen Sie zuerst das Repository klonen:
+If you want to build the image yourself, you must first clone the repository:
 
 ```bash
 # Repository klonen
@@ -36,58 +36,58 @@ cd smartredirectsuite
 docker build -t smartredirect-suite .
 ```
 
-Anschließend können Sie das selbst gebaute Image starten:
+You can then start the self-built image:
 
 ```bash
 docker run -d -p 5000:5000 smartredirect-suite
 ```
 
-## ⚙️ Konfiguration
+## ⚙️ Configuration
 
-Die Anwendung wird über Umgebungsvariablen konfiguriert.
+The application is configured via environment variables.
 
-| Variable | Beschreibung | Standard | Erforderlich |
+| Variable | Description | Standard | Necessary |
 |----------|-------------|---------|----------|
-| `PORT` | Der Port, auf dem die App im Container lauscht. | `5000` | Nein |
-| `NODE_ENV` | Umgebungsmodus (`production` oder `development`). | `production` | Nein |
-| `ADMIN_PASSWORD` | Passwort für das Admin-Panel. **Dringend empfohlen.** | `Password1` | **Ja (Prod)** |
-| `SESSION_SECRET` | Schlüssel für Session-Cookies. Wenn nicht gesetzt, wird bei jedem Start ein zufälliger Schlüssel generiert (Sessions laufen ab). | (Zufällig) | Nein |
-| `LOGIN_MAX_ATTEMPTS` | Max. Login-Versuche vor temporärer Sperre. | `5` | Nein |
-| `LOGIN_BLOCK_DURATION_MS` | Sperrdauer in ms nach Fehlversuchen. | `86400000` (24h) | Nein |
-| `IMPORT_PREVIEW_LIMIT` | Maximale Anzahl an Regeln für Import-Vorschau. | `1000` | Nein |
+| `PORT` | The port on which the app listens in the container. | `5000` | No |
+| `NODE_ENV` | Environment mode (`production` or `development`). | `production` | No |
+| `ADMIN_PASSWORD` | Admin panel password. **Strongly recommended.** | `Password1` | **Me (Prod)** |
+| `SESSION_SECRET` | Key for session cookies. If not set, a random key will be generated at every start (sessions expire). | (Randomly) | No |
+| `LOGIN_MAX_ATTEMPTS` | Max login attempts before temporary ban. | `5` | No |
+| `LOGIN_BLOCK_DURATION_MS` | Blocking duration in ms after failed attempts. | `86400000` (24h) | No |
+| `IMPORT_PREVIEW_LIMIT` | Maximum number of import preview rules. | `1000` | No |
 
 
-### Externe Datenbank konfigurieren
+### Configure external database
 
-SmartRedirect Suite verwendet standardmäßig eine SQLite-Datenbank (`database.sqlite`), die im `/app/data` Volume abgelegt wird. Wenn Sie eine externe Datenbank wie MariaDB/MySQL oder PostgreSQL verwenden möchten, können Sie die entsprechenden Umgebungsvariablen setzen:
+By default, SmartRedirect Suite uses an SQLite database (`database.sqlite`) located in the `/app/data` volume. If you want to use an external database such as MariaDB/MySQL or PostgreSQL, you can set the appropriate environment variables:
 
-| Variable | Beschreibung | Standard |
+| Variable | Description | Standard |
 |----------|-------------|---------|
-| `DB_DIALECT` | Datenbanktyp: `sqlite`, `postgres`, `mysql` oder `mariadb` | `sqlite` |
-| `DB_HOST` | Hostname der Datenbank. | `localhost` |
-| `DB_PORT` | Port der Datenbank (z.B. 5432 für Postgres, 3306 für MariaDB). | `5432` / `3306` |
-| `DB_NAME` | Name der Datenbank. | `smartredirect` |
-| `DB_USER` | Benutzername für die Datenbank. | `root` |
-| `DB_PASSWORD` | Passwort für die Datenbank. | |
+| `DB_DIALECT` | Database type: `sqlite`, `postgres`, `mysql` or `mariadb` | `sqlite` |
+| `DB_HOST` | Database hostname. | `localhost` |
+| `DB_PORT` | Port of the database (e.g. 5432 for Postgres, 3306 for MariaDB). | `5432` / `3306` |
+| `DB_NAME` | Name of the database. | `smartredirect` |
+| `DB_USER` | Username for the database. | `root` |
+| `DB_PASSWORD` | Password for the database. | |
 
-Es stehen `docker-compose.mariadb.yml` und `docker-compose.postgresql.yml` im Repository als Vorlagen zur Verfügung.
+There are `docker-compose.mariadb.yml` and `docker-compose.postgresql.yml` available as templates in the repository.
 
-## 💾 Datenpersistenz
+## 💾 Data persistence
 
-Die SmartRedirect Suite nutzt dateibasierten Speicher für Regeln, Einstellungen und Sessions. Um Datenverlust beim Neustart des Containers zu vermeiden, **müssen** Volumes eingebunden werden.
+The SmartRedirect Suite uses file-based storage for rules, settings and sessions. To avoid data loss when restarting the container, volumes **must** be mounted.
 
-| Pfad im Container | Beschreibung |
+| Path in the container | Description |
 |-------------------|-------------|
-| `/app/data` | Speichert `rules.json`, `settings.json` und Admin-Sessions. |
+| `/app/data` | Stores `rules.json`, `settings.json` and admin sessions. |
 
-**Hinweis zu Berechtigungen:**
-Stellen Sie sicher, dass die eingebundenen Verzeichnisse auf dem Host beschreibbar sind. Da das Dockerfile standardmäßig als `root` läuft, funktionieren Standardberechtigungen in der Regel problemlos.
+**Note about permissions:**
+Make sure the mounted directories on the host are writable. Since the Dockerfile runs as `root` by default, standard permissions usually work without any problems.
 
-## 🐳 Docker Compose (Empfohlen)
+## 🐳 Docker Compose (Recommended)
 
-Für Produktionsumgebungen ist `docker-compose` die einfachste Art der Verwaltung.
+For production environments, `docker-compose` is the easiest way to manage.
 
-Erstellen Sie eine `docker-compose.yml`:
+Create a `docker-compose.yml`:
 
 ```yaml
 services:
@@ -115,26 +115,26 @@ services:
       start_period: 10s
 ```
 
-Dienst starten:
+Start service:
 
 ```bash
 docker-compose up -d
 ```
 
-Logs einsehen:
+View logs:
 
 ```bash
 docker-compose logs -f
 ```
 
-## 🔒 Best Practices für die Produktion
+## 🔒 Production best practices
 
-1.  **Standard-Zugangsdaten ändern:** Setzen Sie immer ein starkes `ADMIN_PASSWORD`.
-2.  **Session Secret:** Setzen Sie ein festes `SESSION_SECRET`, wenn Admin-Sitzungen auch nach einem Container-Neustart gültig bleiben sollen. Ohne diese Variable wird bei jedem Start ein neuer Sicherheitsschlüssel generiert, was alle bestehenden Logins ungültig macht.
-3.  **Reverse Proxy verwenden:** Exponieren Sie Port 5000 nicht direkt ins Internet. Nutzen Sie Nginx, Traefik oder Caddy für SSL-Terminierung (HTTPS) und leiten Sie Anfragen an den Container weiter.
-    *   Setzen Sie den `X-Forwarded-Proto` Header im Proxy, damit die App HTTPS erkennt.
-3.  **Backups:** Sichern Sie regelmäßig das `./data` Verzeichnis auf dem Host-System.
-4.  **Ressourcen-Limits:** Sie können CPU und RAM in der `docker-compose.yml` begrenzen:
+1. **Change default credentials:** Always set a strong `ADMIN_PASSWORD`.
+2. **Session Secret:** Set a fixed `SESSION_SECRET` if you want admin sessions to remain valid even after a container restart. Without this variable, a new security key is generated every time you start, which invalidates all existing logins.
+3. **Use Reverse Proxy:** Do not expose port 5000 directly to the Internet. Use Nginx, Traefik or Caddy for SSL termination (HTTPS) and forward requests to the container.
+    *   Set the `X-Forwarded-Proto` header in the proxy to make the app recognize HTTPS.
+3. **Backups:** Regularly back up the `./data` directory on the host system.
+4. **Resource Limits:** You can limit CPU and RAM in `docker-compose.yml`:
     ```yaml
     deploy:
       resources:

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -1,12 +1,12 @@
 # SmartRedirect Suite - Enterprise Production Deployment Guide
 
-> **Zielgruppe**: DevOps-Engineers, System-Administratoren und Enterprise-Entwickler. Für Standard-Installation siehe [INSTALLATION.md](./INSTALLATION.md). Für API-Integration konsultieren Sie [API_DOCUMENTATION.md](./API_DOCUMENTATION.md).
+> **Target group**: DevOps engineers, system administrators and enterprise developers. For standard installation see [INSTALLATION.md](./INSTALLATION.md). For API integration, see [API_DOCUMENTATION.md](./API_DOCUMENTATION.md).
 
-## 📚 Verwandte Dokumentation
-- **[README.md](../README.md)**: Vollständige Feature-Übersicht und Entwicklungsrichtlinien
+## 📚 Related documentation
+- **[README.md](../README.md)**: Complete feature overview and development guidelines
 - **[DOCKER_DEPLOYMENT.md](./DOCKER_DEPLOYMENT.md)**: Docker Deployment Guide
-- **[INSTALLATION.md](./INSTALLATION.md)**: Lokale Entwicklungsumgebung einrichten
-- **[API_DOCUMENTATION.md](./API_DOCUMENTATION.md)**: REST API-Referenz für Monitoring-Integration
+- **[INSTALLATION.md](./INSTALLATION.md)**: Set up local development environment
+- **[API_DOCUMENTATION.md](./API_DOCUMENTATION.md)**: REST API reference for monitoring integration
 
 ## Overview
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,15 +1,15 @@
-# 🚀 Schnellstart-Anleitung - SmartRedirect Suite
+# 🚀 Quick Start Guide - SmartRedirect Suite
 
-> **Hinweis**: Diese Schnellstart-Anleitung bietet eine vereinfachte Installation. Für detaillierte Informationen siehe [README.md](../README.md). Für Enterprise-Deployments konsultieren Sie [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md).
+> **Note**: This quick start guide provides a simplified installation. For detailed information, see [README.md](../README.md). For enterprise deployments, see [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md).
 
-## 📚 Verwandte Dokumentation
-- **[README.md](../README.md)**: Vollständige Dokumentation mit allen Features
+## 📚 Related documentation
+- **[README.md](../README.md)**: Complete documentation with all features
 - **[DOCKER_DEPLOYMENT.md](./DOCKER_DEPLOYMENT.md)**: Docker Deployment Guide
-- **[API_DOCUMENTATION.md](./API_DOCUMENTATION.md)**: REST API-Referenz für Entwickler
+- **[API_DOCUMENTATION.md](./API_DOCUMENTATION.md)**: REST API reference for developers
 - **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: Production-Deployment-Anleitung
-- **Dockerfile.demo**: Docker-Setup für Demo-Instanzen mit täglichem Daten-Reset
+- **Dockerfile.demo**: Docker setup for demo instances with daily data reset
 
-## 1. Voraussetzungen prüfen
+## 1. Check requirements
 
 ```bash
 # Node.js Version prüfen (benötigt: v18+)
@@ -30,7 +30,7 @@ cp .env.example .env
 # Bearbeiten Sie .env mit Ihren Werten
 ```
 
-## 3. Anwendung starten
+## 3. Start application
 
 ```bash
 # Entwicklungsmodus (mit Hot-Reload)
@@ -41,41 +41,41 @@ npm run build
 npm start
 ```
 
-## 4. Zugriff
+## 4. Access
 
-- **Hauptanwendung**: http://localhost:5000
-- **Admin-Panel**: http://localhost:5000 → Zahnrad-Symbol klicken oder `?admin=true` an die URL anhängen
-- **Standard Admin-Passwort**: `Password1` (ändern Sie dies in der .env-Datei!)
-- **Brute-Force-Schutz**: Nach `LOGIN_MAX_ATTEMPTS` Fehlversuchen wird die IP für `LOGIN_BLOCK_DURATION_MS` ms gesperrt (Standard: 5 Versuche/24h, anpassbar in `.env`)
+- **Main Application**: http://localhost:5000
+- **Admin Panel**: http://localhost:5000 → Click the gear icon or append `?admin=true` to the URL
+- **Default Admin Password**: `Password1` (change this in the .env file!)
+- **Brute force protection**: After `LOGIN_MAX_ATTEMPTS` failed attempts, the IP is blocked for `LOGIN_BLOCK_DURATION_MS` ms (default: 5 attempts/24h, customizable in `.env`)
 
-## 5. Erste Schritte
+## 5. Getting started
 
-1. **Admin einloggen** mit Standard-Passwort
-   - Automatische Session-Persistenz: Bleiben Sie nach Refresh eingeloggt
-2. **Neue URL-Regel erstellen**:
-   - URL-Matcher: `/alte-seite/`
-   - Ziel-URL: `/neue-seite/`
+1. **Log in as admin** with standard password
+   - Automatic session persistence: Stay logged in after refresh
+2. **Create new URL rule**:
+   - URL matcher: `/old-page/`
+   - Target URL: `/new-page/`
    - Typ: `redirect`
-   - **Hinweis**: Intelligente Validierung verhindert echte URL-Konflikte
-3. **Einstellungen anpassen**: Texte und Farben nach Bedarf
-4. **Tab-Navigation**: Gewählte Admin-Tabs bleiben nach Aktualisierung erhalten
-5. **Testen**: Besuchen Sie http://localhost:5000/alte-seite/
+   - **Note**: Smart validation prevents real URL conflicts
+3. **Customize settings**: Texts and colors as required
+4. **Tab navigation**: Selected admin tabs are retained after updating
+5. **Test**: Visit http://localhost:5000/alte-seite/
 
-## 6. Problemlösung
+## 6. Problem solving
 
-**Port bereits belegt?**
+**Port already occupied?**
 ```bash
 # Anderen Port verwenden
 PORT=3000 npm run dev
 ```
 
-**Admin-Passwort vergessen?**
+**Forgot your admin password?**
 ```bash
 # In .env-Datei ändern oder Standard verwenden
 echo "ADMIN_PASSWORD=Password1" >> .env
 ```
 
-**Daten zurücksetzen?**
+**Reset data?**
 ```bash
 # Lösche alle gespeicherten Daten
 rm -rf data/
@@ -83,22 +83,22 @@ rm -rf data/
 npm run dev
 ```
 
-## 7. Erweiterte Funktionen
+## 7. Advanced features
 
-### Multi-Select-Funktionen (Desktop)
-- **Bulk-Operationen**: Mehrere Regeln gleichzeitig bearbeiten
-- **Checkboxes**: Einzelauswahl oder "Alle auswählen"
-- **Mobile-Hinweis**: Automatische Benachrichtigung für mobile Nutzer
+### Multi-select functions (desktop)
+- **Bulk Operations**: Edit multiple rules at the same time
+- **Checkboxes**: Single selection or "Select all"
+- **Mobile Notice**: Automatic notification for mobile users
 
-### Automatische Weiterleitung
-- **Global**: Alle URLs automatisch weiterleiten
-- **Regel-spezifisch**: Pro Regel konfigurierbar
-- **Admin-Zugang**: `?admin=true` Parameter bei aktiver Auto-Weiterleitung
+### Automatic redirection
+- **Global**: Automatically forward all URLs
+- **Rule-specific**: Configurable per rule
+- **Admin access**: `?admin=true` parameter when auto-forwarding is active
 
-## 8. Nächste Schritte
+## 8. Next steps
 
-- **[README.md](./README.md)**: Detaillierte Feature-Dokumentation lesen
+- **[README.md](./README.md)**: Read detailed feature documentation
 - **[API_DOCUMENTATION.md](./API_DOCUMENTATION.md)**: API-Integration planen
-- **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: Production-Deployment vorbereiten
-- Eigene URL-Regeln konfigurieren und Multi-Select testen
-- Einstellungen an Corporate Design anpassen
+- **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: Prepare production deployment
+- Configure your own URL rules and test multi-select
+- Adapt settings to corporate design

--- a/docs/OPENSHIFT_DEPLOYMENT.md
+++ b/docs/OPENSHIFT_DEPLOYMENT.md
@@ -1,36 +1,36 @@
 # OpenShift Deployment Guide - SmartRedirect Suite
 
-> **Zielgruppe**: OpenShift-Administratoren und DevOps-Engineers. Für Standard-Installation siehe [INSTALLATION.md](./INSTALLATION.md). Für Enterprise-Features konsultieren Sie [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md).
+> **Audience**: OpenShift administrators and DevOps engineers. For standard installation see [INSTALLATION.md](./INSTALLATION.md). For enterprise features, see [ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md).
 
-## 📚 Verwandte Dokumentation
-- **[README.md](../README.md)**: Vollständige Feature-Übersicht und Anwendungsdokumentation
-- **[INSTALLATION.md](./INSTALLATION.md)**: Lokale Entwicklungsumgebung für Testing
-- **[API_DOCUMENTATION.md](./API_DOCUMENTATION.md)**: REST API-Referenz für Integration
-- **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: Allgemeine Enterprise-Deployment-Strategien
+## 📚 Related documentation
+- **[README.md](../README.md)**: Complete feature overview and application documentation
+- **[INSTALLATION.md](./INSTALLATION.md)**: Local development environment for testing
+- **[API_DOCUMENTATION.md](./API_DOCUMENTATION.md)**: REST API reference for integration
+- **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: General enterprise deployment strategies
 
-## Überblick
+## Overview
 
-Diese Anleitung beschreibt die Bereitstellung der URL Migration Tool Anwendung auf OpenShift mit persistenter Datenspeicherung und produktionstauglicher Konfiguration.
-Die Anwendung speichert alle Daten ausschließlich im Dateisystem; eine Datenbank wird nicht verwendet.
+This guide describes how to deploy the URL Migration Tool application on OpenShift with persistent data storage and production-grade configuration.
+The application stores all data exclusively in the file system; a database is not used.
 
-## Voraussetzungen
+## Requirements
 
-### OpenShift-Umgebung
-- OpenShift 4.10+ (empfohlen 4.12+)
-- `oc` CLI installiert und konfiguriert
-- Cluster-Admin-Berechtigung oder ausreichende Projekt-Berechtigungen
-- Zugriff auf eine Container Registry (z.B. quay.io, Docker Hub)
+### OpenShift environment
+- OpenShift 4.10+ (recommended 4.12+)
+- `oc` CLI installed and configured
+- Cluster admin permission or sufficient project permissions
+- Access to a container registry (e.g. quay.io, Docker Hub)
 
-### Lokale Entwicklungstools
-- Docker oder Podman für Container-Build
-- Node.js 18+ für lokale Tests
-- Git für Source Code Management
+### Local development tools
+- Docker or Podman for container build
+- Node.js 18+ for local testing
+- Git for source code management
 
-> Hinweis: Für Demo-Instanzen steht ein separates `Dockerfile.demo` bereit, das die Anwendung alle 24h zurücksetzt.
+> Note: A separate `Dockerfile.demo` is available for demo instances, which resets the application every 24 hours.
 
-## 1. Projekt-Setup
+## 1. Project-Setup
 
-### OpenShift-Projekt erstellen
+### Create OpenShift project
 ```bash
 # Neues Projekt erstellen
 oc new-project smartredirect-suite
@@ -42,7 +42,7 @@ oc project smartredirect-suite
 oc label namespace smartredirect-suite app=smartredirect-suite
 ```
 
-### Service Account konfigurieren
+### Configure service account
 ```bash
 # Service Account für die Anwendung erstellen
 oc create serviceaccount smartredirect-sa
@@ -51,13 +51,13 @@ oc create serviceaccount smartredirect-sa
 oc adm policy add-scc-to-user anyuid -z smartredirect-sa
 ```
 
-## 2. Persistent Storage konfigurieren
+## 2. Configure persistent storage
 
-Die Anwendung speichert Konfigurationen, Sitzungen und Uploads ausschließlich im Dateisystem. Eine Datenbank wird nicht benötigt.
+The application stores configurations, sessions and uploads exclusively in the file system. A database is not required.
 
-### Persistent Volume Claims erstellen
+### Create persistent volume claims
 
-**Wichtig**: Die Anwendung benötigt nur **ein** persistentes Volume für `/app/data`. Uploads werden standardmäßig in `/app/data/uploads` und Sessions in `/app/data/sessions` gespeichert.
+**Important**: The application only requires **one** persistent volume for `/app/data`. By default, uploads are stored in `/app/data/uploads` and sessions in `/app/data/sessions`.
 
 ```yaml
 # Erstelle pvc-data.yaml
@@ -81,7 +81,7 @@ spec:
 oc apply -f pvc-data.yaml
 ```
 
-### Storage-Klassen prüfen
+### Check storage classes
 ```bash
 # Verfügbare Storage-Klassen anzeigen
 oc get storageclass
@@ -94,7 +94,7 @@ oc get storageclass
 
 ## 3. Secrets und ConfigMaps
 
-### Application Secrets erstellen
+### Create Application Secrets
 ```bash
 # Admin-Passwort und Session-Secret erstellen
 oc create secret generic smartredirect-secrets \
@@ -107,35 +107,35 @@ oc create secret tls smartredirect-tls \
   --key=path/to/tls.key
 ```
 
-### ConfigMap für Anwendungseinstellungen
+### ConfigMap for application settings
 
-**Wichtiger Hinweis**: Die Anwendung unterstützt nur spezifische Umgebungsvariablen. Hier sind die tatsächlich von der Anwendung gelesenen Variablen:
+**Important Note**: The application only supports specific environment variables. Here are the actual variables read by the application:
 
-**Unterstützte Umgebungsvariablen:**
-- `NODE_ENV` - Umgebung (development/production)
+**Supported environment variables:**
+- `NODE_ENV` - environment (development/production)
 - `PORT` - Server-Port (Standard: 5000)
-- `ADMIN_PASSWORD` - Passwort für den Administrationsbereich
-- `SESSION_SECRET` - Geheimer Schlüssel für Sessions
-- `LOCAL_UPLOAD_PATH` - **einziger konfigurierbarer Pfad** für Logo-Uploads (Standard: ./data/uploads – **innerhalb** des `data`-Verzeichnisses!)
-- `COOKIE_DOMAIN` - Domain für Cookies (nur in Production)
-- `LOGIN_MAX_ATTEMPTS` - maximale Fehlversuche bevor eine IP gesperrt wird (Standard: 5)
-- `LOGIN_BLOCK_DURATION_MS` - Sperrdauer in Millisekunden nach Erreichen der Fehlversuche (Standard: 86400000)
+- `ADMIN_PASSWORD` - Password for the administration area
+- `SESSION_SECRET` - Secret key for sessions
+- `LOCAL_UPLOAD_PATH` - **only configurable path** for logo uploads (default: ./data/uploads – **within** the `data` directory!)
+- `COOKIE_DOMAIN` - Domain for cookies (only in production)
+- `LOGIN_MAX_ATTEMPTS` - maximum failed attempts before an IP is blocked (default: 5)
+- `LOGIN_BLOCK_DURATION_MS` - Blocking duration in milliseconds after reaching the failed attempts (default: 86400000)
 
-**Nicht unterstützte Variablen** (fest codiert in der Anwendung):
-- `DATA_PATH` - Daten werden immer in `./data` gespeichert
-- `SESSION_PATH` - Sessions werden immer in `./data/sessions` gespeichert
-- `LOG_LEVEL` - Logging ist fest konfiguriert
-- `ALLOWED_ORIGINS` - CORS wird über andere Mechanismen gesteuert
+**Unsupported variables** (hard-coded in the application):
+- `DATA_PATH` - Data is always stored in `./data`
+- `SESSION_PATH` - Sessions are always stored in `./data/sessions`
+- `LOG_LEVEL` - Logging is permanently configured
+- `ALLOWED_ORIGINS` - CORS is controlled via other mechanisms
 
-### Wie Environment Variables funktionieren
+### How Environment Variables work
 
-Die Anwendung verwendet `dotenv/config` (siehe `server/index.ts` Zeile 1), was bedeutet:
+The application uses `dotenv/config` (see `server/index.ts` line 1), which means:
 
-1. **Lokale Entwicklung**: Die Anwendung liest `.env` Dateien automatisch
-2. **OpenShift Deployment**: Environment Variables aus ConfigMaps und Secrets überschreiben automatisch alle `.env` Werte
-3. **Priorität**: OpenShift Environment Variables > .env Datei > Default-Werte im Code
+1. **Local development**: The application reads `.env` files automatically
+2. **OpenShift Deployment**: Environment Variables from ConfigMaps and Secrets automatically overwrite all `.env` values
+3. **Priority**: OpenShift Environment Variables > .env file > default values ​​in code
 
-**Praktisches Beispiel:**
+**Practical example:**
 ```javascript
 // In der Anwendung:
 process.env.SESSION_SECRET || 'default-value'
@@ -146,7 +146,7 @@ process.env.SESSION_SECRET || 'default-value'
 // - Fallback: 'default-value' wenn nichts gesetzt
 ```
 
-Die Anwendung **erkennt automatisch** die Umgebung und verwendet die korrekten Werte ohne zusätzliche Konfiguration.
+The application **automatically** detects the environment and uses the correct values ​​without additional configuration.
 
 ```yaml
 # Erstelle configmap.yaml
@@ -172,9 +172,9 @@ data:
 oc apply -f configmap.yaml
 ```
 
-## 4. Container Image erstellen
+## 4. Create container image
 
-### Dockerfile für OpenShift optimieren
+### Optimize Dockerfile for OpenShift
 ```dockerfile
 # Erstelle Dockerfile
 FROM registry.access.redhat.com/ubi8/nodejs-18:latest
@@ -211,7 +211,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 CMD ["npm", "start"]
 ```
 
-### Image erstellen und pushen
+### Create and push image
 ```bash
 # Image lokal erstellen
 docker build -t smartredirect-suite:latest .
@@ -226,9 +226,9 @@ docker tag smartredirect-suite:latest quay.io/yourorg/smartredirect-suite:v1.4
 docker push quay.io/yourorg/smartredirect-suite:v1.4
 ```
 
-## 5. Deployment konfigurieren
+## 5. Configure deployment
 
-### DeploymentConfig erstellen
+### Create DeploymentConfig
 ```yaml
 # Erstelle deployment.yaml
 apiVersion: apps/v1
@@ -343,9 +343,9 @@ spec:
 oc apply -f deployment.yaml
 ```
 
-## 6. Service und Route konfigurieren
+## 6. Configure service and route
 
-### Service erstellen
+### Create service
 ```yaml
 # Erstelle service.yaml
 apiVersion: v1
@@ -366,7 +366,7 @@ spec:
   type: ClusterIP
 ```
 
-### Route für externen Zugriff
+### Route for external access
 ```yaml
 # Erstelle route.yaml
 apiVersion: route.openshift.io/v1
@@ -398,7 +398,7 @@ oc apply -f route.yaml
 
 ## 7. Monitoring und Logging
 
-### Monitoring konfigurieren
+### Configure monitoring
 ```yaml
 # Erstelle servicemonitor.yaml (falls Prometheus Operator verfügbar)
 apiVersion: monitoring.coreos.com/v1
@@ -418,7 +418,7 @@ spec:
     interval: 30s
 ```
 
-> Der ServiceMonitor nutzt den Gesundheitsendpunkt `/api/health`, da die Anwendung keinen separaten Metrik-Endpunkt bereitstellt.
+> The ServiceMonitor uses the health endpoint `/api/health` because the application does not provide a separate metrics endpoint.
 
 ### Logging-Konfiguration
 ```bash
@@ -429,9 +429,9 @@ oc label pod -l app=smartredirect-suite logging=enabled
 oc logs -f deployment/smartredirect-suite
 ```
 
-## 8. Backup-Strategie
+## 8. Backup Strategy
 
-### Daten-Backup konfigurieren
+### Configure data backup
 ```bash
 # Backup-Job für persistente Daten erstellen
 cat > backup-job.yaml << 'EOF'
@@ -478,9 +478,9 @@ spec:
 oc apply -f backup-job.yaml
 ```
 
-## 9. Deployment durchführen
+## 9. Perform deployment
 
-### Schritt-für-Schritt Deployment
+### Step-by-step deployment
 ```bash
 # 1. Alle Konfigurationen anwenden
 oc apply -f pvc-data.yaml
@@ -517,7 +517,7 @@ curl -X POST https://$ROUTE_URL/api/admin/auth \
   -H "Content-Type: application/json" \
   -d '{"password":"IhrSicheresPasswort123!"}'
 ```
-Die Weboberfläche des Admin-Menüs erreichen Sie über das Zahnrad-Symbol oder unter `https://$ROUTE_URL/?admin=true`.
+You can access the web interface of the admin menu via the gear symbol or under `https://$ROUTE_URL/?admin=true`.
 
 ## 10. Scaling und Performance
 
@@ -582,9 +582,9 @@ oc patch deployment smartredirect-suite -p='
 
 ## 11. Troubleshooting
 
-### Häufige Probleme
+### Common Problems
 
-**Pod startet nicht:**
+**Pod won't start:**
 ```bash
 # Events prüfen
 oc describe pod -l app=smartredirect-suite
@@ -597,7 +597,7 @@ oc get pvc
 oc describe pvc smartredirect-data-pvc
 ```
 
-**Persistente Daten gehen verloren:**
+**Persistent data will be lost:**
 ```bash
 # PVC-Status prüfen
 oc get pvc -o wide
@@ -618,7 +618,7 @@ oc top pods -l app=smartredirect-suite
 curl https://$ROUTE_URL/api/health
 ```
 
-## 12. Updates und Wartung
+## 12. Updates and Maintenance
 
 ### Rolling Updates
 ```bash
@@ -633,7 +633,7 @@ oc rollout status deployment/smartredirect-suite
 oc rollout undo deployment/smartredirect-suite
 ```
 
-### Wartungs-Fenster
+### Maintenance window
 ```bash
 # Wartungsmodus aktivieren (Replicas auf 0)
 oc scale deployment smartredirect-suite --replicas=0
@@ -644,7 +644,7 @@ oc scale deployment smartredirect-suite --replicas=0
 oc scale deployment smartredirect-suite --replicas=2
 ```
 
-## 13. Sicherheit
+## 13. Security
 
 ### Security Context Constraints
 ```yaml
@@ -700,9 +700,9 @@ spec:
   - {}  # Erlaubt alle ausgehenden Verbindungen
 ```
 
-## Support und Weiterführende Informationen
+## Support and further information
 
-### Hilfreiche OpenShift-Kommandos
+### Helpful OpenShift commands
 ```bash
 # Projekt-Ressourcen anzeigen
 oc get all -l app=smartredirect-suite
@@ -720,19 +720,19 @@ oc exec -it deployment/smartredirect-suite -- /bin/bash
 oc port-forward service/smartredirect-suite-service 8080:80
 ```
 
-### Ressourcen-Übersicht
-Nach erfolgreichem Deployment haben Sie folgende Ressourcen:
-- **1 PersistentVolumeClaim** für Daten, Sessions und Uploads
-- **1 Deployment** mit 2 Replicas (skalierbar)
-- **1 Service** für interne Kommunikation
-- **1 Route** für externen HTTPS-Zugriff
-- **1 ConfigMap** für Anwendungseinstellungen
-- **1 Secret** für sensible Daten
+### Resource overview
+After successful deployment you will have the following resources:
+- **1 PersistentVolumeClaim** for data, sessions and uploads
+- **1 deployment** with 2 replicas (scalable)
+- **1 service** for internal communication
+- **1 route** for external HTTPS access
+- **1 ConfigMap** for application settings
+- **1 Secret** for sensitive data
 - **Optional**: HPA, ServiceMonitor, NetworkPolicy
 
-### Kontakt und Support
-- **OpenShift-spezifische Fragen**: Cluster-Administrator
-- **Anwendungssupport**: Siehe [README.md](../README.md)
-- **API-Integration**: Siehe [API_DOCUMENTATION.md](./API_DOCUMENTATION.md)
+### Contact and support
+- **OpenShift specific questions**: Cluster Administrator
+- **Application Support**: See [README.md](../README.md)
+- **API integration**: See [API_DOCUMENTATION.md](./API_DOCUMENTATION.md)
 
-Diese Anleitung stellt eine produktionstaugliche Bereitstellung der SmartRedirect Suite Anwendung auf OpenShift sicher, mit allen notwendigen Sicherheits- und Persistierung-Features.
+These instructions ensure a production-ready deployment of the SmartRedirect Suite application on OpenShift, with all necessary security and persistence features.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1,75 +1,75 @@
-# SmartRedirect Suite - Benutzerhandbuch
+# SmartRedirect Suite - User Guide
 
-Dieses Handbuch beschreibt die tägliche Nutzung der SmartRedirect Suite. Die Anwendung verwaltet mehr als 100.000 URL-Transformationsregeln und unterstützt Migrationen zwischen Domains.
+This manual describes the daily use of the SmartRedirect Suite. The application manages more than 100,000 URL transformation rules and supports migrations between domains.
 
-Den Admin-Bereich öffnen Sie über das Zahnrad-Symbol in der Kopfzeile oder indem Sie `?admin=true` an die URL anhängen.
+You can open the admin area using the gear symbol in the header or by appending `?admin=true` to the URL.
 
 ## General Settings
-Nach der Anmeldung im Admin Area steht ein Menü mit vier Reitern zur Verfügung: **Allgemein**, **Regeln**, **Statistik** und **System & Daten**. Über die Schaltflächen im Kopfbereich können Sie sich abmelden oder den Admin-Bereich schließen.
+After logging into the admin area, a menu with four tabs is available: **General**, **Rules**, **Statistics** and **System & Data**. You can log out or close the admin area using the buttons in the header area.
 
-Im Reiter **Allgemein** lassen sich alle Texte, Farben und Icons der Migration-Anwendung anpassen:
+In the **General** tab, all texts, colors and icons of the migration application can be adjusted:
 
-- **Header**: Titel, Icon oder Logo sowie die Hintergrundfarbe des oberen Bereichs.
-- **Hauptbereich und Hinweis**: Überschrift, Beschreibung, Warn-Icon und Farben für die Hinweismeldung.
-- **Routing & Fallback Behavior (ehemals URL-Vergleich)**:
-  - **Target Domain**: Die Basis-Domain für alle Weiterleitungen (Standard). WICHTIG: Wird auch als Basis für Partial Matches verwendet.
-  - **Fallback Strategy**: Definiert das Verhalten, wenn keine spezifische Regel passt.
-    - *Simple Domain Replacement*: Standardverhalten. Ersetzt nur die Domain, behält den gesamten Pfad bei.
-    - *Smart Search Redirect*: Extrahiert das letzte Pfadsegment und leitet auf eine konfigurierbare Suchseite weiter (z.B. `?q=dateiname.pdf`).
-      - **Regex-Extraktion**: Optional kann ein regulärer Ausdruck definiert werden, um den Suchbegriff flexibel aus der URL zu extrahieren (z.B. aus Query-Parametern mit `[?&]file=([^&]+)`).
-      - **Fallback**: Greift der Regex nicht oder ist keiner definiert, wird automatisch das letzte Pfadsegment verwendet.
-  - **Fallback Info Messages**: Konfigurierbare Texte für den Fall, dass keine Regel greift (Smart Search Message) oder kein spezifischer Regeltext vorhanden ist (Standard Info Text).
-  - **Visualisierung**: Titel, Icon, Hintergrundfarbe und Bezeichnungen für alte und neue URL sowie Button-Texte. Zusätzlich können die Interaktionsmöglichkeiten auf der Migrationsseite gesteuert werden (Ein-/Ausblenden der Buttons zum Kopieren oder Öffnen der URL und Konfiguration des Klickverhaltens der angezeigten URL).
-- **Spezielle Hinweise**: Überschrift und Icon für den Hinweisbereich.
-- **Zusätzliche Informationen**: Titel, Icon und bis zu drei Stichpunkte.
-- **Footer**: Copyright-Hinweis.
-- **Automatische Weiterleitung**: Globale Aktivierung einer sofortigen Weiterleitung für alle Regeln.
+- **Header**: Title, icon or logo as well as the background color of the top area.
+- **Main area and notice**: Heading, description, warning icon and colors for the warning message.
+- **Routing & Fallback Behavior (formerly URL comparison)**:
+  - **Target Domain**: The base domain for all redirects (default). IMPORTANT: Also used as a basis for partial matches.
+  - **Fallback Strategy**: Defines the behavior when no specific rule matches.
+    - *Simple Domain Replacement*: Default behavior. Replaces only the domain, keeps the entire path.
+    - *Smart Search Redirect*: Extracts the last path segment and redirects to a configurable search page (e.g. `?q=filename.pdf`).
+      - **Regex extraction**: Optionally, a regular expression can be defined to flexibly extract the search term from the URL (e.g. from query parameters with `[?&]file=([^&]+)`).
+      - **Fallback**: If the regex does not work or is not defined, the last path segment is automatically used.
+  - **Fallback Info Messages**: Configurable texts in the event that no rule applies (Smart Search Message) or no specific rule text is available (Standard Info Text).
+  - **Visualization**: Title, icon, background color and names for old and new URL as well as button texts. In addition, the interaction options on the migration page can be controlled (showing/hiding the buttons for copying or opening the URL and configuring the click behavior of the displayed URL).
+- **Special Notes**: Heading and icon for the information area.
+- **Additional information**: title, icon and up to three bullet points.
+- **Footer**: Copyright notice.
+- **Automatic forwarding**: Globally enable instant forwarding for all rules.
 
-## Regeln verwalten
-1. **Neue Regel** anlegen: URL-Matcher, Ziel-URL, Redirect-Typ (*Teilweise* - ersetzt nur den Anfang, *Vollständig* - ersetzt den gesamten Pfad, oder *Domain*), optionaler Info-Text und automatische Weiterleitung konfigurieren.
-   - **Parameter-Behandlung**:
-     - Bei *Teilweise/Domain*: Option "Alle Link-Parameter entfernen" (Standard: Aus/Parameter behalten).
-     - Bei *Vollständig*: Option "Link-Parameter beibehalten" (Standard: Aus/Parameter entfernen).
-2. **Regeln suchen, sortieren und paginieren**: Eingabe im Suchfeld, Sortierung nach Quelle, Ziel oder Erstellungsdatum.
-3. **Regeln bearbeiten oder löschen**: Einzelne Einträge per Aktionen oder mehrere markierte Regeln gesammelt entfernen.
-4. **Bulk-Löschung**: Mehrere Regeln auf der aktuellen Seite markieren und gemeinsam löschen.
+## Manage rules
+1. **Create a new rule**: URL matcher, target URL, redirect type (*Partial* - replaces only the beginning, *Full* - replaces the entire path, or *Domain*), optional info text and configure automatic redirection.
+   - **Parameter Handling**:
+     - For *Partial/Domain*: Option "Remove all link parameters" (default: Off/Keep parameters).
+     - For *Complete*: "Keep link parameters" option (default: Off/Remove parameters).
+2. **Search, sort and paginate rules**: Enter in the search field, sort by source, target or creation date.
+3. **Edit or delete rules**: Remove individual entries using actions or collectively remove several marked rules.
+4. **Bulk Deletion**: Mark multiple rules on the current page and delete them together.
 
-## Statistik
-- **Top 100**: Häufigste aufgerufene Pfade, filterbar nach Zeitraum (24h, 7 Tage, alle Zeit).
-- **Alle Einträge**: Vollständige Liste der Tracking-Daten mit Such- und Sortierfunktion.
-- **Pagination**: Anzeige der Gesamtanzahl und Navigation zwischen Seiten.
+## Statistics
+- **Top 100**: Most frequently accessed paths, filterable by time period (24h, 7 days, all time).
+- **All Entries**: Complete list of tracking data with search and sorting functionality.
+- **Pagination**: Display the total number and navigate between pages.
 
-## System & Daten
-Der Bereich "System & Daten" ist in drei Bereiche unterteilt, um verschiedene Anwendungsfälle abzudecken.
+## System & Data
+The System & Data section is divided into three sections to cover different use cases.
 
-### 1. Standard Import / Export (Excel, CSV)
-Dieser Bereich ist für die tägliche Pflege von Weiterleitungen optimiert.
-- **Export**: Laden Sie alle Regeln als Excel- (.xlsx) oder CSV-Datei herunter.
-- **Import**: Unterstützt Excel und CSV.
-  - **Vorschau**: Vor dem eigentlichen Import wird eine Vorschau angezeigt, die neue, zu aktualisierende und ungültige Regeln auflistet.
-  - **Spalten**: Die Import-Datei sollte folgende Spalten enthalten (Groß-/Kleinschreibung der Header ist egal, Deutsch/Englisch unterstützt):
-    - `Matcher` / `Quelle` (Pflicht): Der Quell-Pfad oder die Domain.
-    - `Target URL` / `Ziel` (Pflicht): Das Ziel der Weiterleitung.
-    - `Type` / `Typ` (Pflicht): 'partial' (Teilweise), 'wildcard' (Vollständig) oder 'domain'.
-    - `Info` / `Beschreibung` (Optional): Interner Notiztext.
-    - `Auto Redirect` (Optional): 'true'/'false' oder '1'/'0'.
-    - `Discard Query Params` / `Parameter entfernen` (Optional): 'true'/'false'. Entfernt alle Parameter bei Partial/Domain-Regeln.
-    - `Keep Query Params` / `Parameter behalten` (Optional): 'true'/'false'. Behält Parameter bei Wildcard-Regeln.
-    - `ID` (Optional): Wird nur benötigt, um explizit bestehende Regeln zu aktualisieren.
-  - **Option: URLs automatisch kodieren**: Wenn aktiviert (Standard), werden Sonderzeichen in URLs beim Import automatisch kodiert (z.B. Leerzeichen zu `%20`).
-  - **Musterdateien**: Im UI können Vorlagen für Excel und CSV heruntergeladen werden.
+### 1. Standard import/export (Excel, CSV)
+This area is optimized for daily maintenance of redirects.
+- **Export**: Download all rules as an Excel (.xlsx) or CSV file.
+- **Import**: Supports Excel and CSV.
+  - **Preview**: Before the actual import, a preview is displayed that lists new, updated and invalid rules.
+  - **Columns**: The import file should contain the following columns (headers are case sensitive, German/English supported):
+    - `Matcher` / `Source` (mandatory): The source path or domain.
+    - `Target URL` / `Target` (mandatory): The target of the redirect.
+    - `Type` / `Typ` (Mandatory): 'partial' (Partial), 'wildcard' (Full) or 'domain'.
+    - `Info` / `Description` (Optional): Internal note text.
+    - `Auto Redirect` (Optional): 'true'/'false' or '1'/'0'.
+    - `Discard Query Params` / `Remove Parameters` (Optional): 'true'/'false'. Removes all parameters from partial/domain rules.
+    - `Keep Query Params` / `Keep Parameters` (Optional): 'true'/'false'. Retains parameters in wildcard rules.
+    - `ID` (Optional): Only needed to explicitly update existing rules.
+  - **Option: Automatically encode URLs**: If activated (default), special characters in URLs are automatically encoded during import (e.g. spaces to `%20`).
+  - **Sample files**: Templates for Excel and CSV can be downloaded in the UI.
 
-### 2. Erweiterter Regel-Import/Export (JSON)
-Für System-Backups und Experten.
-- Arbeitet mit dem rohen JSON-Format der Datenbank.
-- **Keine Vorschau**: Daten werden direkt importiert.
-- **Warnung**: Regeln mit identischer ID werden sofort überschrieben.
+### 2. Advanced rule import/export (JSON)
+For system backups and experts.
+- Works with the raw JSON format of the database.
+- **No preview**: Data is imported directly.
+- **Warning**: Rules with identical IDs will be overwritten immediately.
 
-### 3. System & Statistiken
-- **System-Einstellungen**: Exportieren/Importieren Sie die gesamte Konfiguration (Texte, Farben, Icons) als JSON-Backup.
-- **Statistiken**: Exportieren Sie die Tracking-Logs aller erfolgten Weiterleitungen als CSV zur externen Analyse.
+### 3. System & Statistics
+- **System Settings**: Export/import the entire configuration (texts, colors, icons) as a JSON backup.
+- **Statistics**: Export the tracking logs of all redirects made as CSV for external analysis.
 
-### 4. Wartung
-- **Cache neu aufbauen**: Erzwingt ein Neuladen aller Regeln in den Arbeitsspeicher. Nur bei Anzeigeproblemen notwendig.
+### 4. Maintenance
+- **Rebuild Cache**: Forces all rules to be reloaded into memory. Only necessary if there are display problems.
 
-Weiterführende Setup-Hinweise finden sich in [INSTALLATION.md](./INSTALLATION.md).
+Further setup instructions can be found in [INSTALLATION.md](./INSTALLATION.md).

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -1,82 +1,82 @@
-# Release Pipeline Dokumentation
+# Release pipeline documentation
 
-Diese Dokumentation beschreibt die Einrichtung und Funktionsweise der automatisierten Release-Pipeline für dieses Projekt.
+This documentation describes how to set up and work the automated release pipeline for this project.
 
-## Überblick
+## Overview
 
-Wir verwenden **GitHub Actions** für die CI/CD-Pipeline. Der Prozess ist vollständig automatisiert und umfasst:
-1.  **Tests & Build:** Bei jedem Push und Pull Request.
-2.  **Versionierung:** Automatische Erhöhung der Version in `package.json` basierend auf Commits (SemVer).
-3.  **Release:** Erstellung von GitHub Releases und Git Tags.
-4.  **Docker Registry:** Bauen und Pushen des Docker-Images in die GitHub Container Registry (GHCR).
+We use **GitHub Actions** for the CI/CD pipeline. The process is fully automated and includes:
+1. **Testing & Build:** On every push and pull request.
+2. **Versioning:** Automatically increment version in `package.json` based on commits (SemVer).
+3. **Release:** Creation of GitHub releases and Git tags.
+4. **Docker Registry:** Build and push the Docker image to the GitHub Container Registry (GHCR).
 
-## Komponenten
+## Components
 
 ### 1. Workflow-Datei (`.github/workflows/ci-cd.yml`)
 
-Dies ist die zentrale Steuerdatei. Sie definiert zwei Jobs:
-*   `test`: Führt `npm test` und `npm run build` aus, um die Integrität des Codes sicherzustellen.
-*   `release`: Führt den Release-Prozess aus. Dieser Job läuft nur auf dem `main`-Branch und nur, wenn die Tests erfolgreich waren.
+This is the central control file. It defines two jobs:
+*   `test`: Runs `npm test` and `npm run build` to ensure code integrity.
+*   `release`: Runs the release process. This job only runs on the `main` branch and only if the tests were successful.
 
 ### 2. Semantic Release Konfiguration (`.releaserc.json`)
 
-Wir nutzen `semantic-release` zur Steuerung der Versionierung. Die Konfiguration beinhaltet folgende Plugins:
-*   `@semantic-release/commit-analyzer`: Analysiert Commit-Messages, um die nächste Version zu bestimmen (Major, Minor, Patch).
-*   `@semantic-release/release-notes-generator`: Generiert Release-Notes aus den Commits.
-*   `@semantic-release/changelog`: Erstellt/Aktualisiert die `CHANGELOG.md`.
-*   `@semantic-release/npm`: Aktualisiert die Version in `package.json` und `package-lock.json`.
-*   `@semantic-release/git`: Committet die geänderten Dateien (`package.json`, `CHANGELOG.md`) zurück in das Repository.
-*   `@semantic-release/github`: Erstellt das Release auf GitHub.
+We use `semantic-release` to control versioning. The configuration includes the following plugins:
+*   `@semantic-release/commit-analyzer`: Analyzes commit messages to determine the next release (major, minor, patch).
+*   `@semantic-release/release-notes-generator`: Generates release notes from the commits.
+*   `@semantic-release/changelog`: Creates/updates the `CHANGELOG.md`.
+*   `@semantic-release/npm`: Updates the version in `package.json` and `package-lock.json`.
+*   `@semantic-release/git`: Commits the changed files (`package.json`, `CHANGELOG.md`) back to the repository.
+*   `@semantic-release/github`: Creates the release on GitHub.
 
-## Workflow-Ablauf
+## Workflow flow
 
-1.  Ein Entwickler pusht Code auf den `main`-Branch (oder merged einen Pull Request).
-2.  Der **Test-Job** startet und verifiziert den Code.
-3.  Bei Erfolg startet der **Release-Job**:
-    *   `semantic-release` analysiert die Commits seit dem letzten Tag.
-    *   Wird eine neue Version benötigt (z.B. durch einen `feat:` oder `fix:` Commit), wird:
-        *   Die Version in `package.json` erhöht.
-        *   `CHANGELOG.md` aktualisiert.
-        *   Ein neuer Git Tag (z.B. `v1.3.0`) erstellt.
-        *   Ein GitHub Release erstellt.
-    *   Anschließend wird das **Docker Image** gebaut:
+1. A developer pushes code to the `main` branch (or merges a pull request).
+2. The **Test job** starts and verifies the code.
+3. If successful, the **release job** starts:
+    *   `semantic-release` analyzes commits since the last day.
+    *   If a new version is required (e.g. through a `feat:` or `fix:` commit), then:
+        *   Increased the version in `package.json`.
+        *   `CHANGELOG.md` updated.
+        *   A new Git tag (e.g. `v1.3.0`) created.
+        *   Created a GitHub release.
+    *   The **Docker Image** is then built:
         *   Tag: `ghcr.io/<owner>/<repo>:v1.3.0`
         *   Tag: `ghcr.io/<owner>/<repo>:latest`
         *   Push in die GitHub Container Registry.
-    *   Abschließend wird der Link zum Docker Image den Release-Notes auf GitHub hinzugefügt.
+    *   Finally, the link to the Docker image is added to the release notes on GitHub.
 
-## Einrichtung & Voraussetzungen
+## Setup & Requirements
 
-### GitHub Repository Einstellungen
+### GitHub repository settings
 
-Damit der Workflow reibungslos funktioniert, müssen folgende Einstellungen im GitHub Repository geprüft werden:
+In order for the workflow to work smoothly, the following settings must be checked in the GitHub repository:
 
 1.  **Actions Permissions:**
-    *   Gehe zu *Settings* -> *Actions* -> *General*.
+    *   Go to *Settings* -> *Actions* -> *General*.
     *   Unter **Workflow permissions**, wähle **Read and write permissions**.
-    *   Aktiviere "Allow GitHub Actions to create and approve pull requests" (optional, aber hilfreich).
+    *   Enable "Allow GitHub Actions to create and approve pull requests" (optional but helpful).
 
 2.  **Container Registry:**
-    *   Das Docker Image wird unter `ghcr.io` veröffentlicht. Die Berechtigung erfolgt automatisch über den `GITHUB_TOKEN` des Workflows.
-    *   Nach dem ersten Push kann die Sichtbarkeit des Pakets (Package Settings) von "Private" auf "Public" gestellt werden, falls gewünscht.
+    *   The Docker image is published at `ghcr.io`. The authorization is done automatically via the `GITHUB_TOKEN` of the workflow.
+    *   After the first push, the visibility of the package (Package Settings) can be changed from "Private" to "Public" if desired.
 
 3.  **Secrets:**
-    *   Es sind **keine manuellen Secrets** erforderlich. Der Workflow nutzt das automatisch generierte `GITHUB_TOKEN`.
+    *   **No manual secrets** are required. The workflow uses the automatically generated `GITHUB_TOKEN`.
 
-### Commit-Konvention
+### Commit Convention
 
-Damit die Versionierung funktioniert, **müssen** Commits der [Conventional Commits](https://www.conventionalcommits.org/) Konvention folgen:
+For versioning to work, commits **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) convention:
 
 *   `fix: ...` -> Patch Release (0.0.x)
 *   `feat: ...` -> Minor Release (0.x.0)
 *   `BREAKING CHANGE: ...` (im Body oder Footer) -> Major Release (x.0.0)
-*   Andere Typen wie `chore:`, `docs:`, `refactor:` lösen standardmäßig kein Release aus.
+*   Other types like `chore:`, `docs:`, `refactor:` do not trigger a release by default.
 
-Beispiel:
+Example:
 ```bash
 git commit -m "feat: add new user login"
 ```
 
-## Lokale Entwicklung
+## Local development
 
-Die Release-Tools sind als `devDependencies` installiert. Es ist jedoch nicht empfohlen, Releases lokal auszuführen. Der Prozess sollte ausschließlich über die CI/CD-Pipeline laufen.
+The release tools are installed as `devDependencies`. However, it is not recommended to run releases locally. The process should run exclusively via the CI/CD pipeline.


### PR DESCRIPTION
Translated `README.md` and all `.md` files in the `docs/` folder to English using `deep-translator` Python script while making sure to preserve Markdown structures, HTML elements, tables, and links.

---
*PR created automatically by Jules for task [11498577316547762845](https://jules.google.com/task/11498577316547762845) started by @DrunkenHusky*