### PR TITLE
⚡ Bolt: [performance improvement] Optimize rule fetching in paginated tracking entries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,6 @@
 ## 2025-12-13 - [Route-based Code Splitting]
 **Learning:** The application was bundling the large `AdminPage` (with its heavy dependencies like tables and dialogs) into the main bundle, even for regular users visiting just for redirection.
 **Action:** Implemented `React.lazy` and `Suspense` for the `AdminPage` in `App.tsx`. This separates the admin code into a separate chunk (`admin-*.js`), significantly reducing the initial download size for the primary redirection use case.
+## 2024-05-24 - [N+1 Query Issue in Tracking Data]
+**Learning:** The `getTrackingEntriesPaginated` function in `server/storage.ts` was doing a full table scan `UrlRuleModel.findAll()` to enrich a tiny paginated subset of tracking entries. This was a classic N+1 adjacent problem causing unnecessary memory allocation and query overhead as the rules table grew.
+**Action:** When enriching paginated datasets with related model data, avoid unconstrained `findAll()` calls. Always extract unique relationship IDs from the current paginated batch and fetch only those related records using a `WHERE id IN (...)` clause (or `[Op.in]`).

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -796,18 +796,32 @@ export class FileStorage implements IStorage {
 
     const filtered = rows.map(r => r.toJSON() as UrlTracking);
 
-    const rulesRows = await UrlRuleModel.findAll();
-    const rules = rulesRows.map(r => r.toJSON() as UrlRule);
-    const ruleMap = new Map<string, UrlRule>();
-    rules.forEach(r => ruleMap.set(r.id, r));
-
     const startIndex = 0;
     const endIndex = Math.min(startIndex + limit, total);
+    const paginatedEntries = filtered.slice(startIndex, endIndex);
 
-    const entriesWithRules = filtered.slice(startIndex, endIndex).map(t => {
+    // Extract unique rule IDs to avoid N+1 query and fetching all rules
+    const uniqueRuleIds = new Set<string>();
+    paginatedEntries.forEach(t => {
+      if (t.ruleId) uniqueRuleIds.add(t.ruleId);
+      if (t.ruleIds && Array.isArray(t.ruleIds)) {
+        t.ruleIds.forEach((id: string) => uniqueRuleIds.add(id));
+      }
+    });
+
+    const ruleMap = new Map<string, UrlRule>();
+    if (uniqueRuleIds.size > 0) {
+      const rulesRows = await UrlRuleModel.findAll({
+        where: { id: { [Op.in]: Array.from(uniqueRuleIds) } }
+      });
+      const rules = rulesRows.map(r => r.toJSON() as UrlRule);
+      rules.forEach(r => ruleMap.set(r.id, r));
+    }
+
+    const entriesWithRules = paginatedEntries.map(t => {
       const enriched: any = { ...t };
       enriched.rule = t.ruleId ? ruleMap.get(t.ruleId) : undefined;
-      enriched.rules = (t.ruleIds || []).map(id => ruleMap.get(id)).filter(Boolean);
+      enriched.rules = (t.ruleIds || []).map((id: string) => ruleMap.get(id)).filter(Boolean);
       return enriched;
     });
 


### PR DESCRIPTION
💡 **What:** Modified `getTrackingEntriesPaginated` in `server/storage.ts` to extract unique rule IDs from the current paginated tracking entries, and fetch only those specific rules using `[Op.in]`.
🎯 **Why:** The previous logic fetched *all* `UrlRule` records into memory for every tracking pagination request, scaling poorly as the number of rules increased.
📊 **Impact:** Significantly reduces database load and memory allocation, changing the fetch complexity from O(total_rules) to O(paginated_unique_rules).
🔬 **Measurement:** Tested using `npm run test` to verify no regressions in functionality, particularly checking the paginated tracking stats features.

---
*PR created automatically by Jules for task [9886817471047344741](https://jules.google.com/task/9886817471047344741) started by @DrunkenHusky*