### PR TITLE
fix: harden database adapter portability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,20 @@ NODE_ENV=production
 # File Upload Configuration
 # Local file storage path for uploaded logo files
 LOCAL_UPLOAD_PATH=./data/uploads
+
+# Database Configuration
+# sqlite is the default. Use postgres/postgresql, mariadb, or mysql for external databases.
+DB_DIALECT=sqlite
+# SQLite file path; ignored for external databases.
+DB_STORAGE=./data/database.sqlite
+# External database settings (PostgreSQL/MariaDB/MySQL).
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_NAME=smartredirect
+# DB_USER=redirectuser
+# DB_PASSWORD=change-me
+# DB_SSL=false
+# DB_POOL_MAX=5
+# DB_POOL_MIN=0
+# DB_POOL_ACQUIRE_MS=30000
+# DB_POOL_IDLE_MS=10000

--- a/README.md
+++ b/README.md
@@ -418,10 +418,9 @@ Fehler werden detailliert auf Deutsch ausgegeben; bei Validierungsfehlern werden
 
 ## Datenverwaltung
 
-Standardmäßig werden JSON-Dateien im `data/` Verzeichnis genutzt:
+Standardmäßig nutzt SmartRedirect Suite eine SQLite-Datenbank unter `data/database.sqlite`. Bestehende JSON-Dateien aus älteren Versionen (`data/rules.json`, `data/settings.json`, `data/tracking.json`) werden beim Start einmalig in die Datenbank migriert und anschließend als `.bak` gesichert. Admin-Sessions bleiben dateibasiert unter `data/sessions/`.
 
-- `data/rules.json`, `data/settings.json`, `data/tracking.json`
-- `data/sessions/` für Admin-Sessions
+Für produktive Setups kann die Datenbank über `DB_DIALECT` auf `postgres`/`postgresql`, `mariadb` oder `mysql` umgestellt werden. Die Variablen `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` und optional `DB_SSL=true` steuern die Verbindung.
 
 ## Sicherheit
 

--- a/docs/ADMIN_DOCUMENTATION.md
+++ b/docs/ADMIN_DOCUMENTATION.md
@@ -15,7 +15,7 @@ Der Admin-Bereich ist über das Zahnrad-Symbol der Anwendung oder durch Anhänge
 - **Tabellen-Resizing**: In der "Regeln"-Ansicht und der "Import-Vorschau" können Spaltenbreiten individuell angepasst werden. Bewegen Sie dazu die Maus an den rechten Rand einer Spaltenüberschrift, bis der Cursor sich ändert, und ziehen Sie die Spalte auf die gewünschte Breite.
 
 ## Wartung
-- Regelmäßige Backups der `data/`-Verzeichnisse.
+- Regelmäßige Backups der SQLite-Datei `data/database.sqlite` bzw. der externen PostgreSQL/MariaDB/MySQL-Datenbank sowie des `data/`-Verzeichnisses für Sessions und Uploads.
 - Abgelaufene Sessions unter `data/sessions/` bereinigen.
 - Logs und Performance-Metriken gemäß Deployment-Guides überwachen.
 - **Cache neu aufbauen**: Im Admin-Bereich unter "System & Daten" > "Wartung" kann der Regel-Cache manuell neu aufgebaut werden. Dies ist normalerweise nicht erforderlich, kann aber helfen, wenn nach umfangreichen Importen oder Updates Probleme mit Weiterleitungen auftreten.

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -4,13 +4,15 @@ Die Anwendung ist modular aufgebaut und trennt klar zwischen Frontend, Backend u
 
 ## Komponenten
 - **client/**: React 18 + TypeScript Frontend, gebündelt mit Vite.
-- **server/**: Express-basiertes Backend mit Dateispeicher und Session-Handling.
+- **server/**: Express-basiertes Backend mit Sequelize-Datenbankadapter (SQLite standardmäßig, PostgreSQL/MariaDB/MySQL optional), Regel-Cache und dateibasiertem Session-Handling.
 - **shared/**: Gemeinsame TypeScript-Typen und Validierungsschemata.
 
 ## Ablauf
 1. Anfragen erreichen das `server/`-Modul.
-2. Der Server prüft Regeln gegen einen **In-Memory Cache**, der beim Start aus `data/rules.json` geladen wird, um I/O-Latenz zu vermeiden.
-3. Validierte Daten werden an das `client/`-Frontend ausgeliefert.
-4. `shared/` stellt Typdefinitionen und Zod-Schemas für beide Seiten bereit.
+2. Der Server initialisiert den Datenbankadapter aus den `DB_*`-Umgebungsvariablen. Standard ist SQLite unter `data/database.sqlite`; `postgres`/`postgresql`, `mariadb` und `mysql` sind über dieselbe Storage-Schnittstelle nutzbar.
+3. Bestehende JSON-Dateien (`rules.json`, `settings.json`, `tracking.json`) werden beim Start einmalig importiert und danach als `.bak` gesichert.
+4. Der Server prüft Regeln gegen einen **In-Memory Cache**, der aus der Datenbank aufgebaut und nach Regel-Importen/-Änderungen invalidiert wird, um I/O-Latenz zu vermeiden.
+5. Validierte Daten werden an das `client/`-Frontend ausgeliefert.
+6. `shared/` stellt Typdefinitionen und Zod-Schemas für beide Seiten bereit.
 
 Die Architektur ermöglicht die hochperformante Verarbeitung von über 100.000 Regeln durch intelligentes Caching und optimierte Datenstrukturen.

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -63,22 +63,26 @@ SmartRedirect Suite verwendet standardmäßig eine SQLite-Datenbank (`database.s
 
 | Variable | Beschreibung | Standard |
 |----------|-------------|---------|
-| `DB_DIALECT` | Datenbanktyp: `sqlite`, `postgres`, `mysql` oder `mariadb` | `sqlite` |
+| `DB_DIALECT` | Datenbanktyp: `sqlite`, `postgres`/`postgresql`, `mysql` oder `mariadb` | `sqlite` |
 | `DB_HOST` | Hostname der Datenbank. | `localhost` |
 | `DB_PORT` | Port der Datenbank (z.B. 5432 für Postgres, 3306 für MariaDB). | `5432` / `3306` |
 | `DB_NAME` | Name der Datenbank. | `smartredirect` |
 | `DB_USER` | Benutzername für die Datenbank. | `root` |
 | `DB_PASSWORD` | Passwort für die Datenbank. | |
+| `DB_STORAGE` | SQLite-Dateipfad, wenn `DB_DIALECT=sqlite` gesetzt ist. | `/app/data/database.sqlite` |
+| `DB_SSL` | Aktiviert TLS für PostgreSQL/MariaDB/MySQL-Verbindungen (`true`/`false`). | `false` |
+| `DB_POOL_MAX` | Maximale Anzahl gleichzeitiger DB-Verbindungen im Sequelize-Pool. | `5` |
+| `DB_POOL_MIN` | Minimale Anzahl offener DB-Verbindungen im Sequelize-Pool. | `0` |
 
 Es stehen `docker-compose.mariadb.yml` und `docker-compose.postgresql.yml` im Repository als Vorlagen zur Verfügung.
 
 ## 💾 Datenpersistenz
 
-Die SmartRedirect Suite nutzt dateibasierten Speicher für Regeln, Einstellungen und Sessions. Um Datenverlust beim Neustart des Containers zu vermeiden, **müssen** Volumes eingebunden werden.
+Die SmartRedirect Suite nutzt standardmäßig SQLite für Regeln, Einstellungen und Tracking sowie dateibasierte Admin-Sessions. Um Datenverlust beim Neustart des Containers zu vermeiden, **müssen** Volumes eingebunden werden.
 
 | Pfad im Container | Beschreibung |
 |-------------------|-------------|
-| `/app/data` | Speichert `rules.json`, `settings.json` und Admin-Sessions. |
+| `/app/data` | Speichert `database.sqlite`, migrierte JSON-Backups (`*.bak`) und Admin-Sessions. |
 
 **Hinweis zu Berechtigungen:**
 Stellen Sie sicher, dass die eingebundenen Verzeichnisse auf dem Host beschreibbar sind. Da das Dockerfile standardmäßig als `root` läuft, funktionieren Standardberechtigungen in der Regel problemlos.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:../vite.config",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "test:unit": "tsx tests/shared/appMetadata.test.ts && tsx tests/client/url-utils.test.ts && tsx tests/shared/url-trace.test.ts",
-    "test": "npm run test:unit && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
+    "test": "npm run test:unit && tsx tests/integration/database-adapter.test.ts && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
     "check": "echo 'Skipping type check'"
   },
   "dependencies": {

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,30 +1,161 @@
-import { Sequelize, DataTypes, Model } from 'sequelize';
+import { Sequelize, DataTypes } from 'sequelize';
+import type { Dialect, Options } from 'sequelize';
 import path from 'path';
+import fs from 'fs/promises';
+import { z } from 'zod';
 
-const dialect = process.env.DB_DIALECT || 'sqlite';
-const storagePath = process.env.DB_STORAGE || path.join(process.cwd(), 'data', 'database.sqlite');
+const dialectAliases = {
+  postgresql: 'postgres',
+} as const;
 
-let sequelize: Sequelize;
+const supportedDialects = ['sqlite', 'postgres', 'mysql', 'mariadb'] as const;
+type SupportedDialect = (typeof supportedDialects)[number];
 
-if (dialect === 'sqlite') {
-  sequelize = new Sequelize({
-    dialect: 'sqlite',
-    storage: storagePath,
-    logging: false,
-  });
-} else {
-  sequelize = new Sequelize(
-    process.env.DB_NAME || 'smartredirect',
-    process.env.DB_USER || 'root',
-    process.env.DB_PASSWORD || '',
-    {
-      host: process.env.DB_HOST || 'localhost',
-      port: parseInt(process.env.DB_PORT || (dialect === 'postgres' ? '5432' : '3306'), 10),
-      dialect: dialect as any,
-      logging: false,
-    }
-  );
+const databaseEnvSchema = z.object({
+  DB_DIALECT: z.string().optional().default('sqlite'),
+  DB_STORAGE: z.string().optional(),
+  DB_NAME: z.string().optional().default('smartredirect'),
+  DB_USER: z.string().optional().default('root'),
+  DB_PASSWORD: z.string().optional().default(''),
+  DB_HOST: z.string().optional().default('localhost'),
+  DB_PORT: z.string().optional(),
+  DB_SSL: z.string().optional().default('false'),
+  DB_POOL_MAX: z.string().optional().default('5'),
+  DB_POOL_MIN: z.string().optional().default('0'),
+  DB_POOL_ACQUIRE_MS: z.string().optional().default('30000'),
+  DB_POOL_IDLE_MS: z.string().optional().default('10000'),
+});
+
+export interface DatabaseConfig {
+  dialect: SupportedDialect;
+  storagePath: string;
+  database: string;
+  username: string;
+  password: string;
+  host: string;
+  port: number;
+  ssl: boolean;
+  pool: {
+    max: number;
+    min: number;
+    acquire: number;
+    idle: number;
+  };
 }
+
+function parsePositiveInteger(value: string, fallback: number, name: string): number {
+  const parsedValue = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsedValue) || parsedValue < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return parsedValue || fallback;
+}
+
+export function normalizeDatabaseDialect(rawDialect: string | undefined): SupportedDialect {
+  const normalizedDialect = (rawDialect || 'sqlite').trim().toLowerCase();
+  const aliasedDialect = dialectAliases[normalizedDialect as keyof typeof dialectAliases] ?? normalizedDialect;
+
+  if (!supportedDialects.includes(aliasedDialect as SupportedDialect)) {
+    throw new Error(
+      `Unsupported DB_DIALECT "${rawDialect}". Supported values: sqlite, postgres/postgresql, mysql, mariadb.`,
+    );
+  }
+
+  return aliasedDialect as SupportedDialect;
+}
+
+export function loadDatabaseConfig(env: NodeJS.ProcessEnv = process.env): DatabaseConfig {
+  const parsedEnvironment = databaseEnvSchema.parse(env);
+  const dialect = normalizeDatabaseDialect(parsedEnvironment.DB_DIALECT);
+  const defaultPort = dialect === 'postgres' ? 5432 : 3306;
+
+  return {
+    dialect,
+    storagePath: parsedEnvironment.DB_STORAGE || path.join(process.cwd(), 'data', 'database.sqlite'),
+    database: parsedEnvironment.DB_NAME,
+    username: parsedEnvironment.DB_USER,
+    password: parsedEnvironment.DB_PASSWORD,
+    host: parsedEnvironment.DB_HOST,
+    port: dialect === 'sqlite'
+      ? 0
+      : parsePositiveInteger(parsedEnvironment.DB_PORT || String(defaultPort), defaultPort, 'DB_PORT'),
+    ssl: parsedEnvironment.DB_SSL.toLowerCase() === 'true',
+    pool: {
+      max: parsePositiveInteger(parsedEnvironment.DB_POOL_MAX, 5, 'DB_POOL_MAX'),
+      min: parsePositiveInteger(parsedEnvironment.DB_POOL_MIN, 0, 'DB_POOL_MIN'),
+      acquire: parsePositiveInteger(parsedEnvironment.DB_POOL_ACQUIRE_MS, 30000, 'DB_POOL_ACQUIRE_MS'),
+      idle: parsePositiveInteger(parsedEnvironment.DB_POOL_IDLE_MS, 10000, 'DB_POOL_IDLE_MS'),
+    },
+  };
+}
+
+function createSequelizeOptions(config: DatabaseConfig): Options {
+  const commonOptions: Options = {
+    dialect: config.dialect as Dialect,
+    logging: false,
+    pool: config.dialect === 'sqlite' ? undefined : config.pool,
+  };
+
+  if (config.dialect === 'sqlite') {
+    return {
+      ...commonOptions,
+      storage: config.storagePath,
+    };
+  }
+
+  return {
+    ...commonOptions,
+    host: config.host,
+    port: config.port,
+    dialectOptions: config.ssl
+      ? {
+          ssl: {
+            require: true,
+            rejectUnauthorized: false,
+          },
+        }
+      : undefined,
+  };
+}
+
+export function createSequelize(config: DatabaseConfig = loadDatabaseConfig()): Sequelize {
+  if (config.dialect === 'sqlite') {
+    return new Sequelize(createSequelizeOptions(config));
+  }
+
+  return new Sequelize(config.database, config.username, config.password, createSequelizeOptions(config));
+}
+
+const databaseConfig = loadDatabaseConfig();
+const sequelize = createSequelize(databaseConfig);
+
+function parseJsonField<T>(value: unknown, fallback: T): T {
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
+
+  if (typeof value !== 'string') {
+    return value as T;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function serializeJsonField(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return JSON.stringify(value);
+}
+
+// Keep Sequelize timestamp columns enabled for compatibility with databases
+// created by the initial adapter implementation. URL rules still store their
+// domain-level creation timestamp in the explicit createdAt field.
+const modelOptions = {};
 
 // Models
 export const UrlRuleModel = sequelize.define('UrlRule', {
@@ -32,7 +163,10 @@ export const UrlRuleModel = sequelize.define('UrlRule', {
     type: DataTypes.TEXT,
     primaryKey: true,
   },
-  matcher: DataTypes.TEXT,
+  matcher: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
   targetUrl: DataTypes.TEXT,
   redirectType: DataTypes.TEXT,
   infoText: DataTypes.TEXT,
@@ -42,34 +176,37 @@ export const UrlRuleModel = sequelize.define('UrlRule', {
   keptQueryParams: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('keptQueryParams');
-      return val ? JSON.parse(val) : [];
+      return parseJsonField(this.getDataValue('keptQueryParams'), []);
     },
-    set(val) {
-      this.setDataValue('keptQueryParams', JSON.stringify(val));
-    }
+    set(value) {
+      this.setDataValue('keptQueryParams', serializeJsonField(value));
+    },
   },
   forwardQueryParams: DataTypes.BOOLEAN,
   searchAndReplace: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('searchAndReplace');
-      return val ? JSON.parse(val) : [];
+      return parseJsonField(this.getDataValue('searchAndReplace'), []);
     },
-    set(val) {
-      this.setDataValue('searchAndReplace', JSON.stringify(val));
-    }
+    set(value) {
+      this.setDataValue('searchAndReplace', serializeJsonField(value));
+    },
   },
   staticQueryParams: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('staticQueryParams');
-      return val ? JSON.parse(val) : [];
+      return parseJsonField(this.getDataValue('staticQueryParams'), []);
     },
-    set(val) {
-      this.setDataValue('staticQueryParams', JSON.stringify(val));
-    }
-  }
+    set(value) {
+      this.setDataValue('staticQueryParams', serializeJsonField(value));
+    },
+  },
+}, {
+  ...modelOptions,
+  indexes: [
+    { fields: ['matcher'] },
+    { fields: ['createdAt'] },
+  ],
 });
 
 export const UrlTrackingModel = sequelize.define('UrlTracking', {
@@ -85,22 +222,20 @@ export const UrlTrackingModel = sequelize.define('UrlTracking', {
   ruleIds: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('ruleIds');
-      return val ? JSON.parse(val) : [];
+      return parseJsonField(this.getDataValue('ruleIds'), []);
     },
-    set(val) {
-      this.setDataValue('ruleIds', val ? JSON.stringify(val) : null);
-    }
+    set(value) {
+      this.setDataValue('ruleIds', serializeJsonField(value));
+    },
   },
   matchedRuleInfo: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('matchedRuleInfo');
-      return val ? JSON.parse(val) : undefined;
+      return parseJsonField(this.getDataValue('matchedRuleInfo'), undefined);
     },
-    set(val) {
-      this.setDataValue('matchedRuleInfo', val ? JSON.stringify(val) : null);
-    }
+    set(value) {
+      this.setDataValue('matchedRuleInfo', serializeJsonField(value));
+    },
   },
   userAgent: DataTypes.TEXT,
   referrer: DataTypes.TEXT,
@@ -112,13 +247,21 @@ export const UrlTrackingModel = sequelize.define('UrlTracking', {
   searchQueryInfo: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('searchQueryInfo');
-      return val ? JSON.parse(val) : undefined;
+      return parseJsonField(this.getDataValue('searchQueryInfo'), undefined);
     },
-    set(val) {
-      this.setDataValue('searchQueryInfo', val ? JSON.stringify(val) : null);
-    }
-  }
+    set(value) {
+      this.setDataValue('searchQueryInfo', serializeJsonField(value));
+    },
+  },
+}, {
+  ...modelOptions,
+  indexes: [
+    { fields: ['timestamp'] },
+    { fields: ['path'] },
+    { fields: ['ruleId'] },
+    { fields: ['feedback'] },
+    { fields: ['matchQuality'] },
+  ],
 });
 
 export const GeneralSettingsModel = sequelize.define('GeneralSettings', {
@@ -126,22 +269,25 @@ export const GeneralSettingsModel = sequelize.define('GeneralSettings', {
     type: DataTypes.TEXT,
     primaryKey: true,
   },
-  // just store everything as a single JSON text field for simplicity,
-  // since settings is a single object
   data: {
     type: DataTypes.TEXT,
+    allowNull: false,
     get() {
-      const val = this.getDataValue('data');
-      return val ? JSON.parse(val) : {};
+      return parseJsonField(this.getDataValue('data'), {});
     },
-    set(val) {
-      this.setDataValue('data', JSON.stringify(val));
-    }
-  }
-});
+    set(value) {
+      this.setDataValue('data', JSON.stringify(value ?? {}));
+    },
+  },
+}, modelOptions);
 
 export async function initDb() {
+  if (databaseConfig.dialect === 'sqlite') {
+    await fs.mkdir(path.dirname(databaseConfig.storagePath), { recursive: true });
+  }
+
+  await sequelize.authenticate();
   await sequelize.sync();
 }
 
-export { sequelize };
+export { sequelize, databaseConfig };

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -30,6 +30,44 @@ function sanitizeRuleFlags(rule: any): any {
 
 const DATA_DIR = path.join(process.cwd(), "data");
 
+const URL_RULE_SORT_COLUMNS = new Set([
+  "matcher",
+  "targetUrl",
+  "redirectType",
+  "createdAt",
+  "autoRedirect",
+]);
+
+const URL_TRACKING_SORT_COLUMNS = new Set([
+  "timestamp",
+  "oldUrl",
+  "newUrl",
+  "path",
+  "referrer",
+  "ruleId",
+  "feedback",
+  "matchQuality",
+]);
+
+function normalizeSortOrder(sortOrder: string | undefined): "ASC" | "DESC" {
+  return sortOrder?.toLowerCase() === "asc" ? "ASC" : "DESC";
+}
+
+function normalizeSortColumn(sortBy: string | undefined, allowedColumns: Set<string>, fallback: string): string {
+  if (sortBy && allowedColumns.has(sortBy)) {
+    return sortBy;
+  }
+
+  return fallback;
+}
+
+function buildCaseInsensitiveLike(columnName: string, query: string) {
+  return sequelize.where(
+    sequelize.fn("lower", sequelize.col(columnName)),
+    { [Op.like]: `%${query.toLowerCase()}%` },
+  );
+}
+
 export interface IStorage {
   // URL-Regeln
   getUrlRules(): Promise<UrlRule[]>;
@@ -123,7 +161,7 @@ export interface IStorage {
     ruleFilter?: 'all' | 'with_rule' | 'no_rule',
     minQuality?: number,
     maxQuality?: number,
-    feedbackFilter?: 'all' | 'OK' | 'NOK' | 'API' | 'empty',
+    feedbackFilter?: 'all' | 'OK' | 'NOK' | 'auto-redirect' | 'API' | 'empty',
   ): Promise<{
     entries: (UrlTracking & { rule?: UrlRule; rules?: UrlRule[] })[];
     total: number;
@@ -352,20 +390,20 @@ export class FileStorage implements IStorage {
     await this.ensureDbReady();
     const offset = (page - 1) * limit;
 
-    let whereClause = {};
-    if (search) {
-      const searchLower = search.toLowerCase();
-      whereClause = {
-        [Op.or]: [
-          { targetUrl: { [Op.like]: `%${searchLower}%` } },
-          { matcher: { [Op.like]: `%${searchLower}%` } }
-        ]
-      };
-    }
+    const whereClause = search
+      ? {
+          [Op.or]: [
+            buildCaseInsensitiveLike("targetUrl", search),
+            buildCaseInsensitiveLike("matcher", search),
+          ],
+        }
+      : {};
+    const safeSortBy = normalizeSortColumn(sortBy, URL_RULE_SORT_COLUMNS, "createdAt");
+    const safeSortOrder = normalizeSortOrder(sortOrder);
 
     const { count, rows } = await UrlRuleModel.findAndCountAll({
       where: whereClause,
-      order: [[sortBy, sortOrder.toUpperCase()]],
+      order: [[safeSortBy, safeSortOrder]],
       limit,
       offset
     });
@@ -503,28 +541,48 @@ export class FileStorage implements IStorage {
     return updatedCount > 0;
   }
 
+  private buildTrackingTimeRangeWhere(timeRange: "24h" | "7d" | "all" = "all") {
+    if (timeRange === "all") {
+      return {};
+    }
+
+    const now = new Date();
+    const timeLimit = new Date(now);
+    if (timeRange === "24h") {
+      timeLimit.setHours(now.getHours() - 24);
+    } else if (timeRange === "7d") {
+      timeLimit.setDate(now.getDate() - 7);
+    }
+
+    return {
+      timestamp: { [Op.gte]: timeLimit.toISOString() },
+    };
+  }
+
   async getTrackingData(
     timeRange: "24h" | "7d" | "all" = "all",
   ): Promise<UrlTracking[]> {
     await this.ensureDbReady();
 
-    let whereClause = {};
-    if (timeRange !== "all") {
-      const now = new Date();
-      const timeLimit = new Date(now);
-      if (timeRange === "24h") {
-        timeLimit.setHours(now.getHours() - 24);
-      } else if (timeRange === "7d") {
-        timeLimit.setDate(now.getDate() - 7);
-      }
-      whereClause = {
-        timestamp: { [Op.gte]: timeLimit.toISOString() }
-      };
-    }
+    const rows = await UrlTrackingModel.findAll({
+      where: this.buildTrackingTimeRangeWhere(timeRange),
+      order: [["timestamp", "DESC"]],
+    });
 
+    return rows.map(r => r.toJSON() as UrlTracking);
+  }
 
-    whereClause.path = {
-      [Op.notIn]: ['/', '/?admin=true', '/?logout=true']
+  async getTopUrls(
+    limit: number = 10,
+    timeRange: "24h" | "7d" | "all" = "all",
+  ): Promise<Array<{ path: string; count: number }>> {
+    await this.ensureDbReady();
+
+    const whereClause: any = {
+      ...this.buildTrackingTimeRangeWhere(timeRange),
+      path: {
+        [Op.notIn]: ['/', '/?admin=true', '/?logout=true']
+      },
     };
 
     const rows = await UrlTrackingModel.findAll({
@@ -537,7 +595,7 @@ export class FileStorage implements IStorage {
 
     return rows.map(r => ({
       path: r.getDataValue('path'),
-      count: parseInt(r.getDataValue('count'), 10)
+      count: Number.parseInt(String(r.getDataValue('count')), 10)
     }));
   }
 
@@ -592,18 +650,19 @@ export class FileStorage implements IStorage {
     sortOrder: "asc" | "desc" = "desc",
   ) {
     await this.ensureDbReady();
-    const queryLower = query.toLowerCase();
+    const safeSortBy = normalizeSortColumn(sortBy, URL_TRACKING_SORT_COLUMNS, "timestamp");
+    const safeSortOrder = normalizeSortOrder(sortOrder);
 
     const rows = await UrlTrackingModel.findAll({
       where: {
         [Op.or]: [
-          { oldUrl: { [Op.like]: `%${queryLower}%` } },
-          { newUrl: { [Op.like]: `%${queryLower}%` } },
-          { path: { [Op.like]: `%${queryLower}%` } },
-          { referrer: { [Op.like]: `%${queryLower}%` } }
+          buildCaseInsensitiveLike("oldUrl", query),
+          buildCaseInsensitiveLike("newUrl", query),
+          buildCaseInsensitiveLike("path", query),
+          buildCaseInsensitiveLike("referrer", query),
         ]
       },
-      order: [[sortBy, sortOrder.toUpperCase()]]
+      order: [[safeSortBy, safeSortOrder]]
     });
 
     return rows.map(r => r.toJSON() as UrlTracking);
@@ -742,54 +801,59 @@ export class FileStorage implements IStorage {
     ruleFilter: 'all' | 'with_rule' | 'no_rule' = 'all',
     minQuality?: number,
     maxQuality?: number,
-    feedbackFilter: 'all' | 'OK' | 'NOK' | 'API' | 'empty' = 'all'
+    feedbackFilter: 'all' | 'OK' | 'NOK' | 'auto-redirect' | 'API' | 'empty' = 'all'
   ) {
     await this.ensureDbReady();
 
-    let whereClause: any = {};
+    const andConditions: any[] = [];
 
     if (search) {
-      const q = search.toLowerCase();
-      whereClause[Op.or] = [
-        sequelize.where(sequelize.fn('lower', sequelize.col('oldUrl')), 'LIKE', `%${q}%`),
-        sequelize.where(sequelize.fn('lower', sequelize.col('newUrl')), 'LIKE', `%${q}%`),
-        sequelize.where(sequelize.fn('lower', sequelize.col('path')), 'LIKE', `%${q}%`),
-        sequelize.where(sequelize.fn('lower', sequelize.col('referrer')), 'LIKE', `%${q}%`)
-      ];
+      andConditions.push({
+        [Op.or]: [
+          buildCaseInsensitiveLike("oldUrl", search),
+          buildCaseInsensitiveLike("newUrl", search),
+          buildCaseInsensitiveLike("path", search),
+          buildCaseInsensitiveLike("referrer", search),
+        ],
+      });
     }
 
     if (ruleFilter === 'with_rule') {
-      whereClause[Op.or] = [
-         { ruleId: { [Op.not]: null } },
-         { ruleIds: { [Op.not]: null, [Op.not]: '[]' } }
-      ];
+      andConditions.push({
+        [Op.or]: [
+          { ruleId: { [Op.not]: null } },
+          { ruleIds: { [Op.not]: null, [Op.ne]: '[]' } },
+        ],
+      });
     } else if (ruleFilter === 'no_rule') {
-      whereClause.ruleId = null;
-      whereClause[Op.or] = [
-         { ruleIds: null },
-         { ruleIds: '[]' }
-      ];
+      andConditions.push({
+        ruleId: null,
+        [Op.or]: [
+          { ruleIds: null },
+          { ruleIds: '[]' },
+        ],
+      });
     }
 
     if (minQuality !== undefined || maxQuality !== undefined) {
-      whereClause.matchQuality = {};
-      if (minQuality !== undefined) whereClause.matchQuality[Op.gte] = minQuality;
-      if (maxQuality !== undefined) whereClause.matchQuality[Op.lte] = maxQuality;
+      const matchQualityFilter: any = {};
+      if (minQuality !== undefined) matchQualityFilter[Op.gte] = minQuality;
+      if (maxQuality !== undefined) matchQualityFilter[Op.lte] = maxQuality;
+      andConditions.push({ matchQuality: matchQualityFilter });
     }
 
     if (feedbackFilter !== 'all') {
-      if (feedbackFilter === 'empty') {
-         whereClause.feedback = null;
-      } else {
-         whereClause.feedback = feedbackFilter;
-      }
+      andConditions.push(feedbackFilter === 'empty' ? { feedback: null } : { feedback: feedbackFilter });
     }
 
+    const whereClause = andConditions.length > 0 ? { [Op.and]: andConditions } : {};
     const offset = (page - 1) * limit;
+    const safeSortBy = normalizeSortColumn(sortBy, URL_TRACKING_SORT_COLUMNS, "timestamp");
+    const safeSortOrder = normalizeSortOrder(sortOrder);
 
     const { count: total, rows } = await UrlTrackingModel.findAndCountAll({
       where: whereClause,
-      order: [[sortBy, sortOrder.toUpperCase()]],
+      order: [[safeSortBy, safeSortOrder]],
       limit,
       offset
     });
@@ -856,13 +920,13 @@ export class FileStorage implements IStorage {
     // or just one by one. For simplicity and robustness, one by one.
 
     for (const importRule of importRules) {
-      const existingById = importRule.id ? await UrlRuleModel.findByPk(importRule.id) : null;
-      const existingByMatcher = await UrlRuleModel.findOne({ where: { matcher: importRule.matcher } });
-
       const isEncoded = /%[0-9A-F]{2}/i.test(importRule.matcher);
       if (isEncoded) {
         importRule.matcher = decodeURI(importRule.matcher);
       }
+
+      const existingById = importRule.id ? await UrlRuleModel.findByPk(importRule.id) : null;
+      const existingByMatcher = await UrlRuleModel.findOne({ where: { matcher: importRule.matcher } });
 
       if (existingById && existingById.getDataValue('matcher') !== importRule.matcher && existingByMatcher) {
         // ID exists but matcher overlaps

--- a/tests/integration/database-adapter.test.ts
+++ b/tests/integration/database-adapter.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "srs-db-adapter-"));
+process.chdir(tempDirectory);
+process.env.DB_DIALECT = "sqlite";
+process.env.DB_STORAGE = path.join(tempDirectory, "data", "adapter.sqlite");
+
+const dbModule = await import("../../server/db");
+const { storage } = await import("../../server/storage");
+
+async function runDatabaseAdapterTests() {
+  console.log("Running database adapter tests...");
+
+  assert.equal(dbModule.normalizeDatabaseDialect("postgresql"), "postgres");
+  assert.equal(dbModule.normalizeDatabaseDialect("mariadb"), "mariadb");
+  assert.throws(
+    () => dbModule.normalizeDatabaseDialect("oracle"),
+    /Unsupported DB_DIALECT/,
+    "Unsupported dialects must fail during configuration validation",
+  );
+
+  const postgresConfig = dbModule.loadDatabaseConfig({
+    DB_DIALECT: "postgresql",
+    DB_NAME: "smartredirect",
+    DB_USER: "redirectuser",
+    DB_PASSWORD: "redirectpass",
+    DB_HOST: "db",
+    DB_SSL: "true",
+  });
+  assert.equal(postgresConfig.dialect, "postgres");
+  assert.equal(postgresConfig.port, 5432);
+  assert.equal(postgresConfig.ssl, true);
+
+  const mariadbConfig = dbModule.loadDatabaseConfig({
+    DB_DIALECT: "mariadb",
+    DB_NAME: "smartredirect",
+    DB_USER: "redirectuser",
+    DB_PASSWORD: "redirectpass",
+    DB_HOST: "db",
+  });
+  assert.equal(mariadbConfig.dialect, "mariadb");
+  assert.equal(mariadbConfig.port, 3306);
+
+  await storage.clearAllRules();
+  await storage.clearAllTracking();
+
+  await storage.createUrlRule({
+    matcher: "/MixedCase-Rule",
+    targetUrl: "https://example.com/target",
+    redirectType: "partial",
+    autoRedirect: false,
+  });
+
+  const paginatedRules = await storage.getUrlRulesPaginated(1, 10, "mixedcase", "not-a-column", "sideways" as "asc");
+  assert.equal(paginatedRules.total, 1, "Rule search must be case-insensitive across supported SQL dialects");
+  assert.equal(paginatedRules.rules[0].matcher, "/MixedCase-Rule");
+
+  await storage.importUrlRules([
+    {
+      matcher: "/caf%C3%A9",
+      targetUrl: "https://example.com/cafe",
+      redirectType: "partial",
+      autoRedirect: false,
+    } as any,
+  ]);
+  await storage.importUrlRules([
+    {
+      matcher: "/café",
+      targetUrl: "https://example.com/cafe-updated",
+      redirectType: "partial",
+      autoRedirect: true,
+    } as any,
+  ]);
+
+  const importedRules = await storage.getUrlRulesPaginated(1, 20, "café", "matcher", "asc");
+  assert.equal(importedRules.total, 1, "Encoded and decoded imports must upsert the same matcher");
+  assert.equal(importedRules.rules[0].targetUrl, "https://example.com/cafe-updated");
+
+  const trackedWithRule = await storage.trackUrlAccess({
+    oldUrl: "https://old.example.com/MixedCase-Rule",
+    newUrl: "https://example.com/target",
+    path: "/MixedCase-Rule",
+    ruleId: paginatedRules.rules[0].id,
+    ruleIds: [paginatedRules.rules[0].id],
+    matchQuality: 100,
+    feedback: "OK",
+    referrer: "https://Referrer.example.com/start",
+  });
+  await storage.trackUrlAccess({
+    oldUrl: "https://old.example.com/no-rule",
+    path: "/no-rule",
+    ruleIds: [],
+    matchQuality: 25,
+    feedback: null,
+    referrer: "https://other.example.com/start",
+  });
+
+  const combinedFilter = await storage.getTrackingEntriesPaginated(
+    1,
+    10,
+    "referrer.example.com",
+    "not-a-column",
+    "desc",
+    "with_rule",
+    90,
+    100,
+    "OK",
+  );
+  assert.equal(combinedFilter.total, 1, "Search, rule, quality, and feedback filters must be combined with AND");
+  assert.equal(combinedFilter.entries[0].id, trackedWithRule.id);
+  assert.equal(combinedFilter.entries[0].rule?.id, paginatedRules.rules[0].id);
+
+  const noRuleFilter = await storage.getTrackingEntriesPaginated(1, 10, undefined, "timestamp", "desc", "no_rule");
+  assert.equal(noRuleFilter.total, 1, "No-rule filter must include entries with empty ruleIds JSON arrays");
+  assert.equal(noRuleFilter.entries[0].path, "/no-rule");
+
+  const allTrackingEntries = await storage.getTrackingData("all");
+  assert.equal(allTrackingEntries.length, 2, "Raw tracking export must return full tracking entries, not grouped top-URL rows");
+  assert.ok(allTrackingEntries.every((entry) => entry.id && entry.oldUrl && entry.timestamp));
+
+  const topUrls = await storage.getTopUrls(10, "all");
+  assert.deepEqual(
+    topUrls.map((entry) => entry.path).sort(),
+    ["/MixedCase-Rule", "/no-rule"].sort(),
+    "Top URL aggregation must stay available for dashboards",
+  );
+
+  await dbModule.sequelize.close();
+  console.log("database adapter tests passed");
+}
+
+runDatabaseAdapterTests().catch(async (error) => {
+  console.error(error);
+  await dbModule.sequelize.close().catch(() => undefined);
+  process.exit(1);
+});

--- a/tests/integration/test-server-features.js
+++ b/tests/integration/test-server-features.js
@@ -16,6 +16,13 @@ if (fs.existsSync(repoDataDir)) {
   // If data dir doesn't exist (e.g. in CI without checkout of data?), create structure
   fs.mkdirSync(path.join(tempDir, "data"), { recursive: true });
 }
+// Ensure database-backed tests start with a clean database even when local data exists.
+for (const databaseFile of ["database.sqlite", "database.sqlite-shm", "database.sqlite-wal"]) {
+  const databasePath = path.join(tempDir, "data", databaseFile);
+  if (fs.existsSync(databasePath)) {
+    fs.rmSync(databasePath, { force: true });
+  }
+}
 // Ensure sessions directory exists for health check
 fs.mkdirSync(path.join(tempDir, "data", "sessions"), { recursive: true });
 


### PR DESCRIPTION
### Motivation
- Replace brittle file-based persistence assumptions with a hardened Sequelize adapter that supports SQLite by default and can be switched to PostgreSQL/MariaDB/MySQL via `DB_DIALECT` while validating configuration and applying safe defaults. 
- Prevent SQL/runtime issues caused by user-controlled sort columns and dialect differences in case-insensitive search, and make tracking exports/aggregations behave predictably across dialects. 
- Ensure migration from legacy `data/*.json` files is safe and only executed once, and fix an import upsert bug where URL-encoded matchers were compared before decoding.
- Assumptions: existing JSON files are migrated once and renamed to `*.bak`; Sequelize timestamp columns are kept enabled for compatibility with older DBs.

### Description
- Reworked `server/db.ts` to add robust DB config parsing/validation (`loadDatabaseConfig`, `normalizeDatabaseDialect`), support `postgresql`→`postgres` alias, optional TLS (`DB_SSL`), pool defaults and safe integer parsing; creates SQLite directory when needed and exposes `databaseConfig` for tests/ops. 
- Replaced ad-hoc JSON serialization in models with `parseJsonField`/`serializeJsonField`, added indexes and kept Sequelize timestamp compatibility; exported `sequelize` and `databaseConfig`. 
- Hardened `server/storage.ts`: whitelist allowed `sortBy` columns, added `buildCaseInsensitiveLike` for portable `lower(...) LIKE` queries, normalized sort order, combined tracking filters using AND semantics, separated raw tracking export (`getTrackingData`) from aggregated top-URL queries (`getTopUrls`), and fixed `importUrlRules` to `decodeURI` matchers before duplicate lookups. 
- Added `tests/integration/database-adapter.test.ts` to validate config normalization, SQLite behavior, case-insensitive search, safe sort handling, encoded-import upserts, combined tracking filters, raw tracking export and top-URL aggregation; updated `tests/integration/test-server-features.js` to remove local SQLite files for reproducible DB-backed tests. 
- Updated `package.json` to include the new integration test in `npm test`, and updated documentation files (`.env.example`, `README.md`, `docs/DOCKER_DEPLOYMENT.md`, `docs/ARCHITECTURE_OVERVIEW.md`, `docs/ADMIN_DOCUMENTATION.md`) to reflect SQLite default, migration behavior and external DB configuration.

### Testing
- Ran full test suite: `npm test` (unit + integration pipeline including the new `database-adapter` test) — all tests passed in CI runs observed. 
- Executed the new integration test directly: `npx tsx tests/integration/database-adapter.test.ts` — passed. 
- Verified build: `npm run build` — succeeded. 
- Type-check: `npx tsc --noEmit` — failed due to pre-existing TypeScript errors outside the scope of this DB adapter change (reported and left unmodified). 
- Security scan: `npm audit --audit-level=high` — audit endpoint returned `403 Forbidden` (registry access issue), so a full SCA report could not be obtained in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f0efbd108331a12ef402f60f24e6)