### PR TITLE
Migrate admin sessions to database and add DatabaseSessionStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Diese Version basiert stets auf dem neuesten Dev-Build, wird alle 24 Stunden zu
 - Zentrale Regelverwaltung mit automatischer URL-Erkennung
 - Kontrollierte Migrationen und nachvollziehbare Domainwechsel
 - Produktivität: Multi-Select, Import/Export von Regeln
-- Admin-Panel mit persistenter Session und anpassbarer UI
+- Admin-Panel mit sicherer Session und anpassbarer UI
 - Intelligente Validierung mit Überlappungserkennung
 - Umfangreiche Statistiken und URL-Tracking
 - Skalierbare Architektur: Verarbeitung von über 100'000 Regeln und Logeinträgen ohne Leistungseinbussen
@@ -418,14 +418,14 @@ Fehler werden detailliert auf Deutsch ausgegeben; bei Validierungsfehlern werden
 
 ## Datenverwaltung
 
-Standardmäßig nutzt SmartRedirect Suite eine SQLite-Datenbank unter `data/database.sqlite`. Bestehende JSON-Dateien aus älteren Versionen (`data/rules.json`, `data/settings.json`, `data/tracking.json`) werden beim Start einmalig in die Datenbank migriert und anschließend als `.bak` gesichert. Admin-Sessions bleiben dateibasiert unter `data/sessions/`.
+Standardmäßig nutzt SmartRedirect Suite eine SQLite-Datenbank unter `data/database.sqlite`. Bestehende JSON-Dateien aus älteren Versionen (`data/rules.json`, `data/settings.json`, `data/tracking.json`) werden beim Start einmalig in die Datenbank migriert und anschließend als `.bak` gesichert. Admin-Sessions werden ebenfalls in der Datenbank gespeichert, aber aus Sicherheitsgründen bei jedem Serverstart vollständig geleert; alte Session-Dateien aus `data/sessions/*.json` werden dabei gelöscht und nicht importiert.
 
 Für produktive Setups kann die Datenbank über `DB_DIALECT` auf `postgres`/`postgresql`, `mariadb` oder `mysql` umgestellt werden. Die Variablen `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` und optional `DB_SSL=true` steuern die Verbindung.
 
 ## Sicherheit
 
-- Persistente Session-Authentifizierung (7 Tage)
-- Sichere Cookies und dateibasierte Sessions
+- Session-Authentifizierung mit 7-Tage-Cookie-Laufzeit innerhalb eines Server-Lebenszyklus
+- Sichere Cookies und datenbankgestützte Sessions
 - Passwortgeschützter Admin-Bereich
 - Brute-Force-Schutz mit IP-Sperre (konfigurierbar über `LOGIN_MAX_ATTEMPTS` und `LOGIN_BLOCK_DURATION_MS`)
 - XSS-Schutz durch React

--- a/docs/ADMIN_DOCUMENTATION.md
+++ b/docs/ADMIN_DOCUMENTATION.md
@@ -15,8 +15,7 @@ Der Admin-Bereich ist über das Zahnrad-Symbol der Anwendung oder durch Anhänge
 - **Tabellen-Resizing**: In der "Regeln"-Ansicht und der "Import-Vorschau" können Spaltenbreiten individuell angepasst werden. Bewegen Sie dazu die Maus an den rechten Rand einer Spaltenüberschrift, bis der Cursor sich ändert, und ziehen Sie die Spalte auf die gewünschte Breite.
 
 ## Wartung
-- Regelmäßige Backups der SQLite-Datei `data/database.sqlite` bzw. der externen PostgreSQL/MariaDB/MySQL-Datenbank sowie des `data/`-Verzeichnisses für Sessions und Uploads.
-- Abgelaufene Sessions unter `data/sessions/` bereinigen.
+- Regelmäßige Backups der SQLite-Datei `data/database.sqlite` bzw. der externen PostgreSQL/MariaDB/MySQL-Datenbank sowie des `data/`-Verzeichnisses für Uploads. Admin-Sessions liegen in derselben Datenbank, werden aber bei jedem Serverstart geleert und zusätzlich bei Ablauf automatisch bereinigt.
 - Logs und Performance-Metriken gemäß Deployment-Guides überwachen.
 - **Cache neu aufbauen**: Im Admin-Bereich unter "System & Daten" > "Wartung" kann der Regel-Cache manuell neu aufgebaut werden. Dies ist normalerweise nicht erforderlich, kann aber helfen, wenn nach umfangreichen Importen oder Updates Probleme mit Weiterleitungen auftreten.
 

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -23,7 +23,7 @@ Development: http://localhost:5000/api
 
 ## Authentication
 
-The API uses session-based authentication for admin operations. All admin endpoints require a valid session.
+The API uses database-backed session authentication for admin operations. All admin endpoints require a valid session cookie.
 
 ### Login
 
@@ -673,7 +673,7 @@ GET /api/health
   },
   "checks": {
     "filesystem": { "status": "ok", "responseTime": 2 },
-    "objectStorage": { "status": "ok", "responseTime": 45 },
+    "storage": { "status": "ok", "responseTime": 45 },
     "sessions": { "status": "ok", "responseTime": 1 }
   }
 }

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -4,15 +4,16 @@ Die Anwendung ist modular aufgebaut und trennt klar zwischen Frontend, Backend u
 
 ## Komponenten
 - **client/**: React 18 + TypeScript Frontend, gebündelt mit Vite.
-- **server/**: Express-basiertes Backend mit Sequelize-Datenbankadapter (SQLite standardmäßig, PostgreSQL/MariaDB/MySQL optional), Regel-Cache und dateibasiertem Session-Handling.
+- **server/**: Express-basiertes Backend mit Sequelize-Datenbankadapter (SQLite standardmäßig, PostgreSQL/MariaDB/MySQL optional), Regel-Cache und datenbankgestütztem Session-Handling.
 - **shared/**: Gemeinsame TypeScript-Typen und Validierungsschemata.
 
 ## Ablauf
 1. Anfragen erreichen das `server/`-Modul.
 2. Der Server initialisiert den Datenbankadapter aus den `DB_*`-Umgebungsvariablen. Standard ist SQLite unter `data/database.sqlite`; `postgres`/`postgresql`, `mariadb` und `mysql` sind über dieselbe Storage-Schnittstelle nutzbar.
-3. Bestehende JSON-Dateien (`rules.json`, `settings.json`, `tracking.json`) werden beim Start einmalig importiert und danach als `.bak` gesichert.
+3. Bestehende JSON-Dateien (`rules.json`, `settings.json`, `tracking.json`) werden beim Start einmalig importiert und danach als `.bak` gesichert. Admin-Sessions werden in der Tabelle `AdminSessions` mit Ablaufindex gespeichert; aktive DB-Sessions und alte `data/sessions/*.json`-Dateien werden bei jedem Serverstart geleert bzw. gelöscht.
 4. Der Server prüft Regeln gegen einen **In-Memory Cache**, der aus der Datenbank aufgebaut und nach Regel-Importen/-Änderungen invalidiert wird, um I/O-Latenz zu vermeiden.
-5. Validierte Daten werden an das `client/`-Frontend ausgeliefert.
-6. `shared/` stellt Typdefinitionen und Zod-Schemas für beide Seiten bereit.
+5. Admin-Routen nutzen Express-Session mit dem `DatabaseSessionStore`; abgelaufene Sessions werden beim Zugriff und zusätzlich periodisch bereinigt, alle bestehenden Sessions zusätzlich beim Serverstart invalidiert.
+6. Validierte Daten werden an das `client/`-Frontend ausgeliefert.
+7. `shared/` stellt Typdefinitionen und Zod-Schemas für beide Seiten bereit.
 
 Die Architektur ermöglicht die hochperformante Verarbeitung von über 100.000 Regeln durch intelligentes Caching und optimierte Datenstrukturen.

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -78,11 +78,11 @@ Es stehen `docker-compose.mariadb.yml` und `docker-compose.postgresql.yml` im Re
 
 ## 💾 Datenpersistenz
 
-Die SmartRedirect Suite nutzt standardmäßig SQLite für Regeln, Einstellungen und Tracking sowie dateibasierte Admin-Sessions. Um Datenverlust beim Neustart des Containers zu vermeiden, **müssen** Volumes eingebunden werden.
+Die SmartRedirect Suite nutzt standardmäßig SQLite für Regeln, Einstellungen, Tracking und Admin-Sessions. Um Datenverlust beim Neustart des Containers zu vermeiden, **müssen** Volumes eingebunden werden.
 
 | Pfad im Container | Beschreibung |
 |-------------------|-------------|
-| `/app/data` | Speichert `database.sqlite`, migrierte JSON-Backups (`*.bak`) und Admin-Sessions. |
+| `/app/data` | Speichert `database.sqlite`, migrierte JSON-Backups (`*.bak`) und Uploads. Aktive Admin-Sessions liegen in der Datenbank, werden aber bei jedem Serverstart geleert. |
 
 **Hinweis zu Berechtigungen:**
 Stellen Sie sicher, dass die eingebundenen Verzeichnisse auf dem Host beschreibbar sind. Da das Dockerfile standardmäßig als `root` läuft, funktionieren Standardberechtigungen in der Regel problemlos.
@@ -134,7 +134,7 @@ docker-compose logs -f
 ## 🔒 Best Practices für die Produktion
 
 1.  **Standard-Zugangsdaten ändern:** Setzen Sie immer ein starkes `ADMIN_PASSWORD`.
-2.  **Session Secret:** Setzen Sie ein festes `SESSION_SECRET`, wenn Admin-Sitzungen auch nach einem Container-Neustart gültig bleiben sollen. Ohne diese Variable wird bei jedem Start ein neuer Sicherheitsschlüssel generiert, was alle bestehenden Logins ungültig macht.
+2.  **Session Secret:** Setzen Sie trotzdem ein festes `SESSION_SECRET`, damit Session-Cookies während der Laufzeit stabil signiert bleiben. Admin-Sitzungen werden beim Serverstart bewusst geleert; ohne diese Variable werden zusätzlich bei jedem Start neue Cookie-Signaturen erzeugt.
 3.  **Reverse Proxy verwenden:** Exponieren Sie Port 5000 nicht direkt ins Internet. Nutzen Sie Nginx, Traefik oder Caddy für SSL-Terminierung (HTTPS) und leiten Sie Anfragen an den Container weiter.
     *   Setzen Sie den `X-Forwarded-Proto` Header im Proxy, damit die App HTTPS erkennt.
 3.  **Backups:** Sichern Sie regelmäßig das `./data` Verzeichnis auf dem Host-System.

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -17,8 +17,8 @@ This document provides comprehensive deployment instructions for the enterprise-
 ### Technology Stack
 - **Frontend**: React 18 + TypeScript + Vite
 - **Backend**: Node.js + Express + TypeScript
-- **Data Storage**: File-based JSON storage
-- **Session Management**: Express-session with file-based persistence
+- **Data Storage**: Sequelize-backed database storage (SQLite by default; PostgreSQL/MariaDB/MySQL optional)
+- **Session Management**: Express-session with database-backed storage and startup invalidation
 - **Object Storage**: Google Cloud Storage integration
 - **Performance**: Virtual scrolling, memory monitoring, and comprehensive in-memory caching for rules and settings
 
@@ -488,11 +488,12 @@ artillery run load-test.yml
 
 3. **Session Issues**
    ```bash
-   # Check session storage
-   ls -la data/sessions/
+   # Check database connectivity; AdminSessions stores active sessions
+   sqlite3 data/database.sqlite "select count(*) from AdminSessions;"
    
-   # Clear expired sessions
-   find data/sessions/ -name "*.json" -mtime +7 -delete
+   # Expired sessions are removed automatically by the application.
+   # AdminSessions is also cleared automatically on every server start.
+   sqlite3 data/database.sqlite "delete from AdminSessions;"
    ```
 
 4. **Object Storage Issues**

--- a/docs/OPENSHIFT_DEPLOYMENT.md
+++ b/docs/OPENSHIFT_DEPLOYMENT.md
@@ -53,11 +53,11 @@ oc adm policy add-scc-to-user anyuid -z smartredirect-sa
 
 ## 2. Persistent Storage konfigurieren
 
-Die Anwendung speichert Konfigurationen, Sitzungen und Uploads ausschließlich im Dateisystem. Eine Datenbank wird nicht benötigt.
+Die Anwendung speichert Konfigurationen, Tracking und Admin-Sessions in der konfigurierten Datenbank (standardmäßig SQLite unter `/app/data/database.sqlite`); Uploads liegen weiterhin im `/app/data`-Volume. Admin-Sessions werden bei jedem Serverstart geleert.
 
 ### Persistent Volume Claims erstellen
 
-**Wichtig**: Die Anwendung benötigt nur **ein** persistentes Volume für `/app/data`. Uploads werden standardmäßig in `/app/data/uploads` und Sessions in `/app/data/sessions` gespeichert.
+**Wichtig**: Bei SQLite benötigt die Anwendung nur **ein** persistentes Volume für `/app/data`. Uploads werden standardmäßig in `/app/data/uploads` gespeichert; aktive Admin-Sessions liegen in der Datenbank, alte Session-Dateien aus `data/sessions/*.json` werden beim Start gelöscht und nicht importiert.
 
 ```yaml
 # Erstelle pvc-data.yaml
@@ -123,7 +123,7 @@ oc create secret tls smartredirect-tls \
 
 **Nicht unterstützte Variablen** (fest codiert in der Anwendung):
 - `DATA_PATH` - Daten werden immer in `./data` gespeichert
-- `SESSION_PATH` - Sessions werden immer in `./data/sessions` gespeichert
+- `SESSION_PATH` - aktive Sessions werden im Datenbankadapter gespeichert; `./data/sessions` wird nur für das Löschen alter JSON-Session-Dateien geprüft
 - `LOG_LEVEL` - Logging ist fest konfiguriert
 - `ALLOWED_ORIGINS` - CORS wird über andere Mechanismen gesteuert
 
@@ -290,7 +290,7 @@ spec:
               key: COOKIE_DOMAIN
         # Persistente Volume Mounts
         # Wichtig: Die Anwendung verwendet fest codierte Pfade relativ zum Arbeitsverzeichnis
-        # /app/data - für JSON-Dateien (rules.json, tracking.json, settings.json), Sessions (/app/data/sessions)
+        # /app/data - für SQLite (database.sqlite), migrierte JSON-Backups
         #           und standardmäßig auch Uploads (/app/data/uploads)
         # Nur ein Volume nötig, da Uploads standardmäßig in ./data/uploads gespeichert werden
         volumeMounts:
@@ -722,7 +722,7 @@ oc port-forward service/smartredirect-suite-service 8080:80
 
 ### Ressourcen-Übersicht
 Nach erfolgreichem Deployment haben Sie folgende Ressourcen:
-- **1 PersistentVolumeClaim** für Daten, Sessions und Uploads
+- **1 PersistentVolumeClaim** für Datenbank und Uploads
 - **1 Deployment** mit 2 Replicas (skalierbar)
 - **1 Service** für interne Kommunikation
 - **1 Route** für externen HTTPS-Zugriff

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:../vite.config",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "test:unit": "tsx tests/shared/appMetadata.test.ts && tsx tests/client/url-utils.test.ts && tsx tests/shared/url-trace.test.ts",
-    "test": "npm run test:unit && tsx tests/integration/database-adapter.test.ts && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
+    "test": "npm run test:unit && tsx tests/integration/database-adapter.test.ts && tsx tests/integration/database-session-store.test.ts && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
     "check": "echo 'Skipping type check'"
   },
   "dependencies": {

--- a/scripts/demo-reset.sh
+++ b/scripts/demo-reset.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 set -e
 
-# Remove session files
+# Remove legacy session files; active sessions are stored in database.sqlite
 rm -rf /app/data/sessions/* || true
 
 # Remove upload files
 rm -rf /app/data/uploads/* || true
 
-# Remove database
-rm -f /app/data/database.sqlite || true
+# Remove database, including rules, settings, tracking and active admin sessions
+rm -f /app/data/database.sqlite /app/data/database.sqlite-shm /app/data/database.sqlite-wal || true
 
 # Start up will regenerate it
 

--- a/server/databaseSessionStore.ts
+++ b/server/databaseSessionStore.ts
@@ -1,0 +1,187 @@
+import { Store, type SessionData } from 'express-session';
+import fs from 'fs/promises';
+import path from 'path';
+import { Op } from 'sequelize';
+import { initDb, AdminSessionModel } from './db';
+
+interface SessionStoreOptions {
+  cleanupIntervalMs?: number;
+  legacySessionsDir?: string;
+}
+
+function normalizeExpiry(value: unknown): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  const expiresAt = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(expiresAt.getTime()) ? null : expiresAt;
+}
+
+function getSessionExpiry(session: SessionData): Date | null {
+  return normalizeExpiry(session.cookie?.expires);
+}
+
+function isExpired(expiresAt: Date | null): boolean {
+  return Boolean(expiresAt && expiresAt.getTime() <= Date.now());
+}
+
+function isValidSessionId(sessionId: string): boolean {
+  return typeof sessionId === 'string'
+    && sessionId.length > 0
+    && sessionId.length <= 255
+    && !/[\u0000-\u001f\u007f]/.test(sessionId);
+}
+
+export class DatabaseSessionStore extends Store {
+  private readonly cleanupIntervalMs: number;
+  private readonly legacySessionsDir: string;
+  private readonly readyPromise: Promise<void>;
+  private cleanupTimer: NodeJS.Timeout | null = null;
+
+  constructor(options: SessionStoreOptions = {}) {
+    super();
+    this.cleanupIntervalMs = options.cleanupIntervalMs ?? 60 * 60 * 1000;
+    this.legacySessionsDir = options.legacySessionsDir ?? path.join(process.cwd(), 'data', 'sessions');
+    this.readyPromise = this.initialize();
+  }
+
+  private async initialize(): Promise<void> {
+    await initDb();
+    await this.pruneExpiredSessions();
+    this.startCleanupTimer();
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.readyPromise;
+  }
+
+  private validateSessionId(sessionId: string): void {
+    if (!isValidSessionId(sessionId)) {
+      throw new Error('Invalid session ID');
+    }
+  }
+
+  override get(sessionId: string, callback: (err: any, session?: SessionData | null) => void): void {
+    (async () => {
+      this.validateSessionId(sessionId);
+      await this.ensureReady();
+
+      const row = await AdminSessionModel.findByPk(sessionId);
+      if (!row) {
+        callback(null, null);
+        return;
+      }
+
+      const expiresAt = normalizeExpiry(row.getDataValue('expiresAt'));
+      if (isExpired(expiresAt)) {
+        await row.destroy();
+        callback(null, null);
+        return;
+      }
+
+      callback(null, row.getDataValue('data') as SessionData);
+    })().catch(error => callback(error));
+  }
+
+  override set(sessionId: string, session: SessionData, callback?: (err?: any) => void): void {
+    (async () => {
+      this.validateSessionId(sessionId);
+      await this.ensureReady();
+
+      const expiresAt = getSessionExpiry(session);
+      await AdminSessionModel.upsert({
+        id: sessionId,
+        data: session,
+        expiresAt: expiresAt?.toISOString() ?? null,
+      } as any);
+      callback?.();
+    })().catch(error => callback?.(error));
+  }
+
+  override destroy(sessionId: string, callback?: (err?: any) => void): void {
+    (async () => {
+      this.validateSessionId(sessionId);
+      await this.ensureReady();
+      await AdminSessionModel.destroy({ where: { id: sessionId } });
+      callback?.();
+    })().catch(error => callback?.(error));
+  }
+
+  override touch(sessionId: string, session: SessionData, callback?: (err?: any) => void): void {
+    this.set(sessionId, session, callback);
+  }
+
+  override all(callback: (err: any, obj?: { [sid: string]: SessionData } | SessionData[] | null) => void): void {
+    (async () => {
+      await this.ensureReady();
+      await this.pruneExpiredSessions();
+      const rows = await AdminSessionModel.findAll();
+      callback(null, rows.map(row => row.getDataValue('data') as SessionData));
+    })().catch(error => callback(error));
+  }
+
+  override length(callback: (err: any, length?: number) => void): void {
+    (async () => {
+      await this.ensureReady();
+      await this.pruneExpiredSessions();
+      const count = await AdminSessionModel.count();
+      callback(null, count);
+    })().catch(error => callback(error));
+  }
+
+  override clear(callback?: (err?: any) => void): void {
+    (async () => {
+      await this.ensureReady();
+      await AdminSessionModel.destroy({ where: {} });
+      await this.clearLegacySessionFiles();
+      callback?.();
+    })().catch(error => callback?.(error));
+  }
+
+  async close(): Promise<void> {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
+  private startCleanupTimer(): void {
+    if (this.cleanupTimer || this.cleanupIntervalMs <= 0) {
+      return;
+    }
+
+    this.cleanupTimer = setInterval(() => {
+      this.pruneExpiredSessions().catch(error => {
+        console.warn('Session cleanup error:', error);
+      });
+    }, this.cleanupIntervalMs);
+    this.cleanupTimer.unref?.();
+  }
+
+  private async pruneExpiredSessions(): Promise<void> {
+    await AdminSessionModel.destroy({
+      where: {
+        expiresAt: {
+          [Op.lt]: new Date().toISOString(),
+        },
+      },
+    });
+  }
+
+  private async clearLegacySessionFiles(): Promise<void> {
+    let files: string[];
+    try {
+      files = await fs.readdir(this.legacySessionsDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+      return;
+    }
+
+    await Promise.all(files
+      .filter(file => file.endsWith('.json'))
+      .map(file => fs.rm(path.join(this.legacySessionsDir, file), { force: true })));
+  }
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -264,6 +264,32 @@ export const UrlTrackingModel = sequelize.define('UrlTracking', {
   ],
 });
 
+export const AdminSessionModel = sequelize.define('AdminSession', {
+  id: {
+    type: DataTypes.TEXT,
+    primaryKey: true,
+  },
+  data: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    get() {
+      return parseJsonField(this.getDataValue('data'), {});
+    },
+    set(value) {
+      this.setDataValue('data', JSON.stringify(value ?? {}));
+    },
+  },
+  expiresAt: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  },
+}, {
+  ...modelOptions,
+  indexes: [
+    { fields: ['expiresAt'] },
+  ],
+});
+
 export const GeneralSettingsModel = sequelize.define('GeneralSettings', {
   id: {
     type: DataTypes.TEXT,
@@ -281,13 +307,21 @@ export const GeneralSettingsModel = sequelize.define('GeneralSettings', {
   },
 }, modelOptions);
 
+let initDbPromise: Promise<void> | null = null;
+
 export async function initDb() {
-  if (databaseConfig.dialect === 'sqlite') {
-    await fs.mkdir(path.dirname(databaseConfig.storagePath), { recursive: true });
+  if (!initDbPromise) {
+    initDbPromise = (async () => {
+      if (databaseConfig.dialect === 'sqlite') {
+        await fs.mkdir(path.dirname(databaseConfig.storagePath), { recursive: true });
+      }
+
+      await sequelize.authenticate();
+      await sequelize.sync();
+    })();
   }
 
-  await sequelize.authenticate();
-  await sequelize.sync();
+  return initDbPromise;
 }
 
 export { sequelize, databaseConfig };

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,7 @@ import helmet from "helmet";
 import { randomBytes } from "crypto";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
-import { FileSessionStore } from "./fileSessionStore";
+import { DatabaseSessionStore } from "./databaseSessionStore";
 import { rateLimitMiddleware, adminRateLimitMiddleware, csrfCheck } from "./middleware/security";
 
 const app = express();
@@ -122,7 +122,7 @@ app.use((req, res, next) => {
 });
 
 // Session configuration
-const sessionStore = new FileSessionStore();
+const sessionStore = new DatabaseSessionStore();
 sessionStore.clear(() => {
   console.log("INFO: Alle existierenden Sitzungen wurden bereinigt.");
 });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { createHash, timingSafeEqual } from "crypto";
 import { storage } from "./storage";
+import { initDb, AdminSessionModel } from "./db";
 import {
   insertUrlTrackingSchema,
   exportRequestSchema,
@@ -82,18 +83,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         };
       }
       
-      // Check sessions by verifying session directory
+      // Check database-backed sessions by querying the AdminSessions table.
       let sessionsCheck = { status: "error", responseTime: 0, error: "" };
       const sessionsStart = Date.now();
       try {
-        const sessionsDir = path.join(dataDir, 'sessions');
-        await fs.access(sessionsDir);
+        await initDb();
+        await AdminSessionModel.count();
         sessionsCheck = { status: "ok" as const, responseTime: Date.now() - sessionsStart, error: "" };
       } catch (error) {
         sessionsCheck = { 
           status: "error" as const, 
           responseTime: Date.now() - sessionsStart, 
-          error: error instanceof Error ? error.message : "Sessions directory not accessible" 
+          error: error instanceof Error ? error.message : "Session database not accessible"
         };
       }
       

--- a/tests/integration/database-session-store.test.ts
+++ b/tests/integration/database-session-store.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "srs-session-store-"));
+process.chdir(tempDirectory);
+process.env.DB_DIALECT = "sqlite";
+process.env.DB_STORAGE = path.join(tempDirectory, "data", "sessions.sqlite");
+
+const { DatabaseSessionStore } = await import("../../server/databaseSessionStore");
+const { AdminSessionModel, sequelize } = await import("../../server/db");
+
+function setSession(store: InstanceType<typeof DatabaseSessionStore>, sessionId: string, session: any): Promise<void> {
+  return new Promise((resolve, reject) => {
+    store.set(sessionId, session, error => error ? reject(error) : resolve());
+  });
+}
+
+function getSession(store: InstanceType<typeof DatabaseSessionStore>, sessionId: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    store.get(sessionId, (error, session) => error ? reject(error) : resolve(session));
+  });
+}
+
+function getLength(store: InstanceType<typeof DatabaseSessionStore>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    store.length((error, length) => error ? reject(error) : resolve(length ?? 0));
+  });
+}
+
+async function runDatabaseSessionStoreTests() {
+  console.log("Running database session store tests...");
+
+  const legacyDirectory = path.join(tempDirectory, "data", "sessions");
+  await fs.mkdir(legacyDirectory, { recursive: true });
+  const store = new DatabaseSessionStore({ legacySessionsDir: legacyDirectory, cleanupIntervalMs: 0 });
+  const expires = new Date(Date.now() + 60_000);
+
+  await setSession(store, "admin-session-1", {
+    cookie: { expires },
+    isAdminAuthenticated: true,
+    adminLoginTime: 123,
+  });
+
+  const persistedRow = await AdminSessionModel.findByPk("admin-session-1");
+  assert.ok(persistedRow, "session must be persisted in the database");
+  assert.equal(persistedRow?.getDataValue("expiresAt"), expires.toISOString());
+
+  const restoredSession = await getSession(store, "admin-session-1");
+  assert.equal(restoredSession.isAdminAuthenticated, true);
+  assert.equal(restoredSession.adminLoginTime, 123);
+  assert.equal(await getLength(store), 1);
+
+  await setSession(store, "expired-session", {
+    cookie: { expires: new Date(Date.now() - 60_000) },
+    isAdminAuthenticated: true,
+  });
+  assert.equal(await getSession(store, "expired-session"), null, "expired sessions must be removed on read");
+  assert.equal(await AdminSessionModel.findByPk("expired-session"), null);
+
+  await fs.writeFile(path.join(legacyDirectory, "legacy-session.json"), JSON.stringify({
+    data: { cookie: { expires }, isAdminAuthenticated: true, adminLoginTime: 456 },
+    expires: expires.toISOString(),
+  }));
+
+  await setSession(store, "session-cleared-on-startup", {
+    cookie: { expires },
+    isAdminAuthenticated: true,
+  });
+  await new Promise<void>((resolve, reject) => {
+    store.clear(error => error ? reject(error) : resolve());
+  });
+
+  assert.equal(await getLength(store), 0, "startup cleanup must remove DB-backed sessions");
+  await assert.rejects(
+    () => fs.access(path.join(legacyDirectory, "legacy-session.json")),
+    /ENOENT/,
+    "startup cleanup must delete legacy JSON sessions instead of importing them",
+  );
+  assert.equal(await AdminSessionModel.findByPk("legacy-session"), null);
+
+  await store.close();
+  await sequelize.close();
+  console.log("database session store tests passed");
+}
+
+runDatabaseSessionStoreTests().catch(async error => {
+  console.error(error);
+  await sequelize.close().catch(() => undefined);
+  process.exit(1);
+});

--- a/tests/integration/test-server-features.js
+++ b/tests/integration/test-server-features.js
@@ -23,15 +23,12 @@ for (const databaseFile of ["database.sqlite", "database.sqlite-shm", "database.
     fs.rmSync(databasePath, { force: true });
   }
 }
-// Ensure sessions directory exists for health check
-fs.mkdirSync(path.join(tempDir, "data", "sessions"), { recursive: true });
-
 process.chdir(tempDir);
 
 // Dynamic imports after changing working directory so storage uses temp data path
 // Note: Dynamic import("./...") resolves relative to the current module file
 const { registerRoutes } = await import("../../server/routes.ts");
-const { FileSessionStore } = await import("../../server/fileSessionStore.ts");
+const { DatabaseSessionStore } = await import("../../server/databaseSessionStore.ts");
 const { APPLICATION_METADATA } = await import("../../shared/appMetadata.ts");
 
 // Helper to start server on random port
@@ -40,7 +37,7 @@ async function startServer() {
   app.use(express.json({ limit: "50mb" }));
   app.use(express.urlencoded({ extended: false, limit: "50mb" }));
   const sessionMiddleware = session({
-    store: new FileSessionStore(),
+    store: new DatabaseSessionStore({ cleanupIntervalMs: 0 }),
     secret: "test-secret",
     resave: false,
     saveUninitialized: false,


### PR DESCRIPTION
### Motivation
- Replace fragile file-based admin session handling with a database-backed store for improved security and centralized management.
- Ensure legacy JSON session files are not imported and are removed to avoid stale or insecure sessions after upgrades.
- Provide deterministic startup behavior by invalidating all admin sessions on server start to reduce attack surface and simplify session lifecycle management.

### Description
- Introduces a new Sequelize model `AdminSession` and `AdminSessionModel` in `server/db.ts` to persist session `id`, `data` and `expiresAt` fields.
- Adds a new `DatabaseSessionStore` in `server/databaseSessionStore.ts` implementing `express-session` store methods with expiry pruning, periodic cleanup, startup invalidation and legacy JSON-session file deletion.
- Switches the application to use `DatabaseSessionStore` in `server/index.ts` and adapts health checks in `server/routes.ts` to verify the `AdminSessions` table via `initDb()`/`AdminSessionModel.count()`.
- Updates docs (`README.md`, `docs/*`) and deployment guides to reflect database-backed sessions, modifies `scripts/demo-reset.sh` to treat DB as source of truth, and updates `package.json` to include `database-session-store` integration test.

### Testing
- Added `tests/integration/database-session-store.test.ts` and updated `tests/integration/test-server-features.js` to exercise the new store, and ran the integration test suite via `npm test`.
- Executed unit tests with `npm run test:unit` and the full test suite with `npm test`, with all automated tests completing successfully.
- Verified the demo reset script behavior by running the cleanup steps which remove DB files and legacy session JSON files as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f8f13f588331b19aa2b150639351)