### PR TITLE
feat: complete translation management and multi-language UI (EN default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SmartRedirect Suite is a web application for centrally managing URL migrations between old and new domains. Typical use case: Migrating from SharePoint On-Premises to SharePoint Online when the domain and path structure change. The app notifies users of outdated links and can automatically redirect to new destinations.
 
-**Demo-Instanz:** [smartredirectsuite.render.com](https://smartredirectsuite.onrender.com/)
+**Demo instance:** [smartredirectsuite.render.com](https://smartredirectsuite.onrender.com/)
 This version is always based on the latest dev build, resets every 24 hours and is suitable for trying out the app.
 
 ☕️ **Coffee for the code?** If you like the SmartRedirect Suite, buy me a coffee on [BuyMeACoffee](https://buymeacoffee.com/drunkenhusky) and keep the bits caffeinated!
@@ -10,47 +10,53 @@ This version is always based on the latest dev build, resets every 24 hours and 
 ## Table of Contents
 
 - [Key Features](#key-features)
-- [Documentation](#dokumentation)
+- [Documentation](#documentation)
 - [Impressions](#impressions)
-- [How it works](#funktionsweise)
-  - [Rule Modes](#regelmodi)
-  - [Examples](#beispiele)
-- [Use Cases](#einsatzszenarien)
-- [Quick Start](#schnellstart)
-  - [Prerequisites](#voraussetzungen)
-  - [1. Repository klonen](#1-repository-klonen)
-  - [2. Install Dependencies](#2-dependencies-installieren)
-  - [3. Create .env file](#3-env-datei-erstellen)
-  - [4. Start Application](#4-anwendung-starten)
+- [How it works](#how-it-works)
+  - [Rule Modes](#rule-modes)
+  - [Examples](#examples)
+- [Use Cases](#use-cases)
+- [Quick Start](#quick-start)
+  - [Prerequisites](#prerequisites)
+  - [1. Clone Repository](#1-clone-repository)
+  - [2. Install Dependencies](#2-install-dependencies)
+  - [3. Create .env file](#3-create-env-file)
+  - [4. Start Application](#4-start-application)
 - [Administration](#administration)
-  - [Import Rules](#regeln-importieren)
-  - [Customize Settings](#einstellungen-anpassen)
+  - [Import Rules](#import-rules)
+  - [Customize Settings](#customize-settings)
   - [Matching Indicator](#matching-indicator)
-  - [Statistics & Monitoring](#statistiken--monitoring)
-- [Release Process](#release-prozess)
-- [Validation & Quality Assurance](#validierung--qualitatssicherung)
-- [Data Management](#datenverwaltung)
-- [Security](#sicherheit)
+  - [Statistics & Monitoring](#statistics--monitoring)
+- [Release Process](#release-process)
+- [Validation & Quality Assurance](#validation--quality-assurance)
+- [Data Management](#data-management)
+- [Security](#security)
 - [Deployment](#deployment)
-- [Development](#entwicklung)
-- [Support & Beitrag](#support--beitrag)
-- [Change History](#anderungshistorie)
+- [Development](#development)
+- [Support & Contributions](#support--contributions)
+- [Change History](#change-history)
 
 ## Key Features
 
 - Central rule management with automatic URL detection
 - Controlled migrations and traceable domain changes
 - Productivity: Multi-select, import/export of rules
-- Admin panel with persistent session and customizable UI
+- Admin panel with persistent session, customizable UI, and translation management
 - Intelligent validation with overlap detection
 - Extensive statistics and URL tracking
 - Scalable architecture: Processing of over 100,000 rules and log entries without sacrificing performance
 - Responsive design for desktop and mobile devices
+- Multi-language UI with browser-language detection, cookie-based language preference, and built-in English, German, Italian, Spanish, and French translations
+
+
+### Language support
+
+SmartRedirect Suite uses English as the default and fallback language. The UI detects the browser language on first load, stores explicit language-switch choices in the `i18next` cookie for seven days, and serves translations from the backend. Administrators can open **Admin → Languages** to edit translations for English, German, Italian, Spanish, and French or add additional BCP 47 language codes such as `pt-br`.
 
 ## Documentation
 
 - [User Manual](./docs/USER_MANUAL.md)
-- [Admin-Documentation](./docs/ADMIN_DOCUMENTATION.md)
+- [Admin Documentation](./docs/ADMIN_DOCUMENTATION.md)
 - [Docker Deployment](./docs/DOCKER_DEPLOYMENT.md)
 - [Architecture Overview](./docs/ARCHITECTURE_OVERVIEW.md)
 - [Configuration Examples](./docs/CONFIGURATION_EXAMPLES.md)
@@ -97,9 +103,9 @@ matches both `/sites/team/docs` and `/archive/sites/team/docs`.
 
 ### Rule Modes
 
-| Modus           | Behave                                                                                                                                           |
+| Mode            | Behavior                                                                                                                                           |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Partially**   | Replaces path segments starting from the matcher. Base URL comes from general settings; additional segments, parameters and anchors are appended. |
+| **Partial**   | Replaces path segments starting from the matcher. Base URL comes from general settings; additional segments, parameters and anchors are appended. |
 | **Complete** | Completely redirects to a new destination URL. No parts of the old URL are retained.                                                      |
 
 ### Case sensitive
@@ -123,22 +129,22 @@ https://intranet.alt.com/sites/team/docs/handbuch.pdf?version=3#kapitel-2
 
 ```
 Matcher: /sites/team
-Neuer Teilpfad: /teams/finance
-Ergebnis: https://neuesintranet.cloud.com/teams/finance/docs/handbuch.pdf?version=3#kapitel-2
+New path segment: /teams/finance
+Result: https://neuesintranet.cloud.com/teams/finance/docs/handbuch.pdf?version=3#kapitel-2
 ```
 
 **Complete**
 
 ```
 Matcher: /sites/team
-Ziel-URL: https://andereseite.com/hub
-Ergebnis: https://andereseite.com/hub
+Target URL: https://andereseite.com/hub
+Result: https://andereseite.com/hub
 ```
 
 **Without rule (domain replacement)**
 
 ```
-Ergebnis: https://neuesintranet.cloud.com/sites/team/docs/handbuch.pdf?version=3#kapitel-2
+Result: https://neuesintranet.cloud.com/sites/team/docs/handbuch.pdf?version=3#kapitel-2
 ```
 
 ### Rule prioritization (specificity)
@@ -256,26 +262,26 @@ Create a `.env` file in the root directory:
 
 ```bash
 cat > .env <<'EOF'
-# Admin Panel Authentifizierung
-ADMIN_PASSWORD=MeinSicheresPasswort123
+# Admin panel authentication
+ADMIN_PASSWORD=MySecurePassword123
 
-# Session-Sicherheit
-SESSION_SECRET=super-geheimer-session-schluessel-hier-einfuegen-mindestens-32-zeichen
+# Session security
+SESSION_SECRET=insert-a-super-secret-session-key-here-minimum-32-characters
 
-# Brute-Force-Schutz (optional)
-# Max. Fehlversuche bevor IP gesperrt wird
+# Brute-force protection (optional)
+# Maximum failed attempts before an IP is blocked
 LOGIN_MAX_ATTEMPTS=5
-# Sperrdauer in Millisekunden (24h)
+# Block duration in milliseconds (24h)
 LOGIN_BLOCK_DURATION_MS=86400000
 
-# Limit für Import-Vorschau (Anzahl Regeln)
+# Import preview limit (number of rules)
 IMPORT_PREVIEW_LIMIT=1000
 
-# Server-Konfiguration
+# Server configuration
 PORT=5000
 NODE_ENV=development
 
-# Datei-Upload Pfad (optional)
+# File upload path (optional)
 # LOCAL_UPLOAD_PATH=./data/uploads
 EOF
 ```
@@ -343,10 +349,10 @@ Example of a JSON file:
 {
   "rules": [
     {
-      "matcher": "/alte-seite/",
-      "targetUrl": "/neue-seite/",
+      "matcher": "/old-page/",
+      "targetUrl": "/new-page/",
       "type": "redirect",
-      "infoText": "Diese Seite wurde verschoben"
+      "infoText": "This page has moved"
     }
   ]
 }
@@ -358,8 +364,8 @@ Upload in the admin panel or view via `sample-rules-import.json`.
 
 In the admin panel, texts, colors and UI elements can be customized, including:
 
-- Header und Icons
-- Popup-Texte
+- Header and icons
+- Popup text
 - Labels in URL comparison
 - Visibility of the buttons (“Copy URL” and “Open in new tab”)
 - Click behavior of the displayed URL (copy, open, or no action)

--- a/client/src/components/LanguageSwitch.tsx
+++ b/client/src/components/LanguageSwitch.tsx
@@ -1,26 +1,52 @@
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Globe } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Globe } from 'lucide-react';
+import { BUILT_IN_LANGUAGES, DEFAULT_LANGUAGE, type LanguageOption } from '@shared/i18n';
+
+const fallbackLanguageOptions: LanguageOption[] = BUILT_IN_LANGUAGES.map((language) => ({
+  ...language,
+  isBuiltIn: true,
+}));
 
 export function LanguageSwitch() {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const { data } = useQuery<{ languages: LanguageOption[] }>({
+    queryKey: ['/api/translations/languages'],
+    queryFn: async () => {
+      const response = await fetch('/api/translations/languages');
+      if (!response.ok) {
+        throw new Error('Failed to load available languages');
+      }
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
 
-  // Exclude cimode which is used for testing
-  const supportedLngs = (i18n.options.supportedLngs || []).filter((l: string) => l !== 'cimode');
-
-  const currentLang = i18n.resolvedLanguage || i18n.language || 'en';
+  const languageOptions = data?.languages?.length ? data.languages : fallbackLanguageOptions;
+  const currentLanguage = i18n.resolvedLanguage || i18n.language || DEFAULT_LANGUAGE;
+  const baseLanguage = currentLanguage.split('-')[0];
+  const selectedLanguage = languageOptions.some((language) => language.code === currentLanguage)
+    ? currentLanguage
+    : languageOptions.some((language) => language.code === baseLanguage)
+      ? baseLanguage
+      : DEFAULT_LANGUAGE;
 
   return (
     <div className="flex items-center space-x-2">
-      <Globe className="h-4 w-4 text-muted-foreground" />
-      <Select value={currentLang} onValueChange={(val) => i18n.changeLanguage(val)}>
-        <SelectTrigger className="w-[80px] h-8 text-xs bg-transparent border-0 ring-offset-0 focus:ring-0 shadow-none hover:bg-accent/50 transition-colors">
-          <SelectValue placeholder="Lang" />
+      <Globe className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+      <Select value={selectedLanguage} onValueChange={(languageCode) => i18n.changeLanguage(languageCode)}>
+        <SelectTrigger
+          aria-label={t('select_language', 'Select language')}
+          className="w-[112px] h-8 text-xs bg-transparent border-0 ring-offset-0 focus:ring-0 shadow-none hover:bg-accent/50 transition-colors"
+        >
+          <SelectValue placeholder={t('language', 'Language')} />
         </SelectTrigger>
         <SelectContent align="end">
-          {supportedLngs.map((lng: string) => (
-            <SelectItem key={lng} value={lng} className="text-xs">
-              {lng.toUpperCase()}
+          {languageOptions.map((language) => (
+            <SelectItem key={language.code} value={language.code} className="text-xs">
+              <span className="font-medium">{language.code.toUpperCase()}</span>
+              <span className="ml-2 text-muted-foreground">{language.nativeName}</span>
             </SelectItem>
           ))}
         </SelectContent>

--- a/client/src/components/admin/TranslationManager.tsx
+++ b/client/src/components/admin/TranslationManager.tsx
@@ -1,222 +1,328 @@
-import { useState, useEffect } from "react";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { useToast } from "@/hooks/use-toast";
-import { useTranslation } from "react-i18next";
-import { Plus, Save, Trash2, Globe, Search } from "lucide-react";
+import { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { useTranslation } from 'react-i18next';
+import { Globe, Plus, Save, Search, Trash2 } from 'lucide-react';
+import { DEFAULT_LANGUAGE, type LanguageOption, assertValidLanguageCode } from '@shared/i18n';
+
+type TranslationResponse = Record<string, string>;
+
+type LanguageListResponse = {
+  languages: LanguageOption[];
+};
+
+function countMissingBaseKeys(baseTranslations: TranslationResponse, translations: TranslationResponse) {
+  return Object.keys(baseTranslations).filter((key) => !translations[key]?.trim()).length;
+}
 
 export function TranslationManager() {
   const { t, i18n } = useTranslation();
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [selectedLang, setSelectedLang] = useState<string>("en");
-  const [editData, setEditData] = useState<Record<string, string>>({});
-  const [newKey, setNewKey] = useState("");
-  const [newVal, setNewVal] = useState("");
-  const [originalData, setOriginalData] = useState<Record<string, string>>({});
-  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedLanguage, setSelectedLanguage] = useState<string>(DEFAULT_LANGUAGE);
+  const [editData, setEditData] = useState<TranslationResponse>({});
+  const [newKey, setNewKey] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [newLanguageCode, setNewLanguageCode] = useState('');
+  const [originalData, setOriginalData] = useState<TranslationResponse>({});
+  const [searchQuery, setSearchQuery] = useState('');
 
-  // Available languages can be fetched or hardcoded based on i18n
-  const supportedLngs = (i18n.options.supportedLngs || []).filter((l: string) => l !== 'cimode');
-
-
-  const { data: baseTranslationData } = useQuery({
-    queryKey: ['/api/translations', 'en'],
+  const { data: languageListData } = useQuery<LanguageListResponse>({
+    queryKey: ['/api/translations/languages'],
     queryFn: async () => {
-      const res = await fetch(`/api/translations/en`);
-      if (!res.ok) throw new Error("Failed to load base translation");
-      return res.json();
-    }
+      const response = await fetch('/api/translations/languages');
+      if (!response.ok) throw new Error('Failed to load available languages');
+      return response.json();
+    },
   });
 
-  const { data: translationData, isLoading } = useQuery({
+  const languageOptions = languageListData?.languages ?? [];
 
-    queryKey: ['/api/translations', selectedLang],
+  const { data: baseTranslationData = {} } = useQuery<TranslationResponse>({
+    queryKey: ['/api/translations', DEFAULT_LANGUAGE],
     queryFn: async () => {
-      const res = await fetch(`/api/translations/${selectedLang}`);
-      if (!res.ok) throw new Error("Failed to load translation");
-      return res.json();
-    }
+      const response = await fetch(`/api/translations/${DEFAULT_LANGUAGE}`);
+      if (!response.ok) throw new Error('Failed to load base translations');
+      return response.json();
+    },
   });
 
+  const { data: translationData = {}, isLoading } = useQuery<TranslationResponse>({
+    queryKey: ['/api/translations', selectedLanguage],
+    queryFn: async () => {
+      const response = await fetch(`/api/translations/${selectedLanguage}`);
+      if (!response.ok) throw new Error('Failed to load translations');
+      return response.json();
+    },
+  });
 
   useEffect(() => {
-    if (translationData && baseTranslationData) {
-      // Create a merged set of keys, prioritizing existing translations, then base keys (with empty value)
-      const mergedData = { ...translationData };
-      if (selectedLang !== 'en') {
-        Object.keys(baseTranslationData).forEach(key => {
-          if (!(key in mergedData)) {
-            mergedData[key] = ""; // Auto-add empty string for missing keys
-          }
-        });
-      }
-      setEditData(mergedData);
-      setOriginalData(translationData); // Original only tracks what is actually in the DB
-    }
-  }, [translationData, baseTranslationData, selectedLang]);
+    const mergedTranslations = { ...translationData };
 
+    if (selectedLanguage !== DEFAULT_LANGUAGE) {
+      Object.keys(baseTranslationData).forEach((key) => {
+        if (!(key in mergedTranslations)) {
+          mergedTranslations[key] = '';
+        }
+      });
+    }
+
+    setEditData(mergedTranslations);
+    setOriginalData(translationData);
+  }, [baseTranslationData, selectedLanguage, translationData]);
 
   const updateMutation = useMutation({
-    mutationFn: async (data: Record<string, string>) => {
-      const res = await fetch(`/api/admin/translations/${selectedLang}`, {
+    mutationFn: async (data: TranslationResponse) => {
+      const response = await fetch(`/api/admin/translations/${selectedLanguage}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data)
+        body: JSON.stringify(data),
       });
-      if (!res.ok) throw new Error("Failed to update translations");
-      return res.json();
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || 'Failed to update translations');
+      }
+
+      return response.json();
     },
-    onSuccess: () => {
-      toast({ title: "Erfolg", description: "Übersetzungen gespeichert." });
-      queryClient.invalidateQueries({ queryKey: ['/api/translations', selectedLang] });
-      // Reload i18n resources
-      i18n.reloadResources([selectedLang]);
+    onSuccess: async () => {
+      toast({
+        title: t('translation_save_success_title', 'Translations saved'),
+        description: t('translation_save_success_description', 'The selected language was updated successfully.'),
+      });
+      await queryClient.invalidateQueries({ queryKey: ['/api/translations'] });
+      await queryClient.invalidateQueries({ queryKey: ['/api/translations/languages'] });
+      await i18n.reloadResources([selectedLanguage]);
     },
-    onError: () => {
-      toast({ title: "Fehler", description: "Konnte Übersetzungen nicht speichern.", variant: "destructive" });
-    }
+    onError: (error) => {
+      toast({
+        title: t('translation_save_error_title', 'Could not save translations'),
+        description: error instanceof Error ? error.message : t('translation_save_error_description', 'Please review the language code and values.'),
+        variant: 'destructive',
+      });
+    },
   });
 
-  const handleSave = () => {
-    updateMutation.mutate(editData);
+  const addLanguageMutation = useMutation({
+    mutationFn: async (languageCode: string) => {
+      const normalizedLanguageCode = assertValidLanguageCode(languageCode);
+      const response = await fetch(`/api/admin/translations/${normalizedLanguageCode}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || 'Failed to add language');
+      }
+
+      return normalizedLanguageCode;
+    },
+    onSuccess: async (languageCode) => {
+      setNewLanguageCode('');
+      setSelectedLanguage(languageCode);
+      await queryClient.invalidateQueries({ queryKey: ['/api/translations/languages'] });
+      toast({
+        title: t('translation_language_added_title', 'Language added'),
+        description: t('translation_language_added_description', 'The language is ready for manual translations.'),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: t('translation_language_error_title', 'Could not add language'),
+        description: error instanceof Error ? error.message : t('translation_language_error_description', 'Use a valid language code such as pt-br.'),
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const filteredKeys = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    const keys = Object.keys(editData).sort((leftKey, rightKey) => leftKey.localeCompare(rightKey));
+
+    if (!normalizedQuery) return keys;
+
+    return keys.filter((key) => {
+      const translatedValue = editData[key] || '';
+      const baseValue = baseTranslationData[key] || '';
+      return [key, translatedValue, baseValue].some((value) => value.toLowerCase().includes(normalizedQuery));
+    });
+  }, [baseTranslationData, editData, searchQuery]);
+
+  const changedCount = Object.keys(editData).filter((key) => originalData[key] !== editData[key]).length;
+  const missingCount = selectedLanguage === DEFAULT_LANGUAGE ? 0 : countMissingBaseKeys(baseTranslationData, editData);
+
+  const handleSave = () => updateMutation.mutate(editData);
+
+  const handleAddKey = () => {
+    const trimmedKey = newKey.trim();
+    if (!trimmedKey) return;
+
+    setEditData((currentData) => ({ ...currentData, [trimmedKey]: newValue }));
+    setNewKey('');
+    setNewValue('');
   };
 
-  const handleChange = (key: string, value: string) => {
-    setEditData(prev => ({ ...prev, [key]: value }));
-  };
-
-  const handleAdd = () => {
-    if (!newKey.trim()) return;
-    setEditData(prev => ({ ...prev, [newKey.trim()]: newVal }));
-    setNewKey("");
-    setNewVal("");
-  };
-
-  const handleDelete = (key: string) => {
-    setEditData(prev => {
-      const newData = { ...prev };
-      delete newData[key];
-      return newData;
+  const handleDeleteKey = (key: string) => {
+    setEditData((currentData) => {
+      const nextData = { ...currentData };
+      delete nextData[key];
+      return nextData;
     });
   };
-
-
-  const filteredKeys = Object.keys(editData).filter((key) => {
-    if (!searchQuery) return true;
-    const query = searchQuery.toLowerCase();
-    return key.toLowerCase().includes(query) || (editData[key] || "").toLowerCase().includes(query);
-  });
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center space-x-2">
-          <Globe className="h-5 w-5" />
-          <span>{t('translations', 'Übersetzungen')}</span>
+          <Globe className="h-5 w-5" aria-hidden="true" />
+          <span>{t('translations', 'Translations')}</span>
         </CardTitle>
         <CardDescription>
-          Übersetzungen für die Anwendung anpassen und neue Sprachen verwalten.
+          {t('translation_manager_description', 'Manage UI copy for built-in languages and add custom languages for international rollouts.')}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="flex items-center space-x-4">
-          <div className="w-48">
-            <Select value={selectedLang} onValueChange={setSelectedLang}>
-              <SelectTrigger>
-                <SelectValue placeholder="Sprache auswählen" />
+        <div className="grid gap-4 lg:grid-cols-[minmax(220px,320px)_1fr]">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="translation-language-select">
+              {t('language', 'Language')}
+            </label>
+            <Select value={selectedLanguage} onValueChange={setSelectedLanguage}>
+              <SelectTrigger id="translation-language-select">
+                <SelectValue placeholder={t('select_language', 'Select language')} />
               </SelectTrigger>
               <SelectContent>
-                {supportedLngs.map((lng: string) => (
-                  <SelectItem key={lng} value={lng}>
-                    {lng.toUpperCase()}
+                {languageOptions.map((language) => (
+                  <SelectItem key={language.code} value={language.code}>
+                    {language.code.toUpperCase()} · {language.nativeName}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
+            <p className="text-xs text-muted-foreground">
+              {selectedLanguage === DEFAULT_LANGUAGE
+                ? t('translation_default_language_hint', 'English is the default and fallback language.')
+                : t('translation_non_default_language_hint', 'Missing values fall back to English until you provide a translation.')}
+            </p>
           </div>
-          <Button onClick={handleSave} disabled={updateMutation.isPending}>
+
+          <div className="rounded-lg border bg-muted/30 p-4">
+            <div className="grid gap-3 sm:grid-cols-[160px_1fr_auto]">
+              <Input
+                aria-label={t('new_language_code', 'New language code')}
+                placeholder={t('language_code_placeholder', 'e.g. pt-br')}
+                value={newLanguageCode}
+                onChange={(event) => setNewLanguageCode(event.target.value)}
+              />
+              <p className="self-center text-sm text-muted-foreground">
+                {t('add_language_help_text', 'Add any BCP 47 style language code. New languages start with English fallback values.')}
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => addLanguageMutation.mutate(newLanguageCode)}
+                disabled={!newLanguageCode.trim() || addLanguageMutation.isPending}
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                {t('add_language', 'Add language')}
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+            <span>{t('translation_key_count', '{{count}} keys', { count: Object.keys(editData).length })}</span>
+            <span>·</span>
+            <span>{t('translation_changed_count', '{{count}} changed', { count: changedCount })}</span>
+            {selectedLanguage !== DEFAULT_LANGUAGE && (
+              <>
+                <span>·</span>
+                <span className={missingCount > 0 ? 'text-amber-600' : 'text-green-600'}>
+                  {t('translation_missing_count', '{{count}} missing', { count: missingCount })}
+                </span>
+              </>
+            )}
+          </div>
+          <Button onClick={handleSave} disabled={updateMutation.isPending || isLoading}>
             <Save className="h-4 w-4 mr-2" />
-            Speichern
+            {t('save', 'Save')}
           </Button>
         </div>
 
-
-        <div className="flex items-center space-x-4">
-          <div className="relative flex-1 max-w-md">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              type="search"
-              placeholder={t('suche_nach_schl_ssel_oder_we', `Suche nach Schlüssel oder Wert...`)}
-              className="pl-8"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-          </div>
+        <div className="relative max-w-md">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <Input
+            type="search"
+            placeholder={t('translation_search_placeholder', 'Search by key, translation, or English fallback...')}
+            className="pl-8"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+          />
         </div>
 
-        <div className="border rounded-md">
+        <div className="border rounded-md overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Schlüssel (Key)</TableHead>
-                <TableHead>Wert (Value)</TableHead>
-                <TableHead className="w-[100px]"></TableHead>
+                <TableHead>{t('translation_key_header', 'Key')}</TableHead>
+                <TableHead>{t('translation_value_header', 'Value')}</TableHead>
+                <TableHead className="w-[100px]" />
               </TableRow>
             </TableHeader>
             <TableBody>
               {filteredKeys.map((key) => {
-                const val = editData[key];
-                const isChanged = originalData[key] !== val;
+                const value = editData[key] ?? '';
+                const isChanged = originalData[key] !== value;
+
                 return (
-
-                <TableRow key={key} className={`${isChanged ? "bg-muted/50" : ""} ${val === "" ? "border-l-4 border-l-red-500" : ""}`}>
-
-                  <TableCell className="font-mono text-sm">
-                    <div className="flex flex-col">
-                      <span>{key} {isChanged && <span className="ml-2 inline-block w-2 h-2 rounded-full bg-yellow-500" title="Unsaved changes" />}</span>
-                      {selectedLang !== 'en' && baseTranslationData && baseTranslationData[key] && (
-                        <span className="text-xs text-muted-foreground mt-1 whitespace-pre-wrap">{baseTranslationData[key]}</span>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Input
-                      value={val}
-                      onChange={(e) => handleChange(key, e.target.value)}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <Button variant="ghost" size="sm" onClick={() => handleDelete(key)}>
-                      <Trash2 className="h-4 w-4 text-red-500" />
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              )})}
+                  <TableRow key={key} className={`${isChanged ? 'bg-muted/50' : ''} ${value === '' ? 'border-l-4 border-l-amber-500' : ''}`}>
+                    <TableCell className="font-mono text-sm align-top">
+                      <div className="flex flex-col gap-1">
+                        <span>
+                          {key}
+                          {isChanged && <span className="ml-2 inline-block w-2 h-2 rounded-full bg-yellow-500" title={t('unsaved_changes', 'Unsaved changes')} />}
+                        </span>
+                        {selectedLanguage !== DEFAULT_LANGUAGE && baseTranslationData[key] && (
+                          <span className="text-xs text-muted-foreground whitespace-pre-wrap">{baseTranslationData[key]}</span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Input value={value} onChange={(event) => setEditData((currentData) => ({ ...currentData, [key]: event.target.value }))} />
+                    </TableCell>
+                    <TableCell>
+                      <Button variant="ghost" size="sm" onClick={() => handleDeleteKey(key)} aria-label={t('delete_translation_key', 'Delete translation key')}>
+                        <Trash2 className="h-4 w-4 text-red-500" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
               <TableRow>
                 <TableCell>
-                  <Input
-                    placeholder="Neuer Schlüssel..."
-                    value={newKey}
-                    onChange={e => setNewKey(e.target.value)}
-                  />
+                  <Input placeholder={t('new_key_placeholder', 'New key...')} value={newKey} onChange={(event) => setNewKey(event.target.value)} />
                 </TableCell>
                 <TableCell>
                   <Input
-                    placeholder="Wert..."
-                    value={newVal}
-                    onChange={e => setNewVal(e.target.value)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') handleAdd();
+                    placeholder={t('value_placeholder', 'Value...')}
+                    value={newValue}
+                    onChange={(event) => setNewValue(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') handleAddKey();
                     }}
                   />
                 </TableCell>
                 <TableCell>
-                  <Button variant="ghost" size="sm" onClick={handleAdd}>
+                  <Button variant="ghost" size="sm" onClick={handleAddKey} aria-label={t('add_translation_key', 'Add translation key')}>
                     <Plus className="h-4 w-4" />
                   </Button>
                 </TableCell>

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -2,17 +2,17 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpBackend from 'i18next-http-backend';
+import { DEFAULT_LANGUAGE } from '@shared/i18n';
 
 i18n
   .use(HttpBackend)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    fallbackLng: 'en',
-    // fallback language if translation missing
-    supportedLngs: ['en', 'de', 'it', 'es', 'fr'],
+    fallbackLng: DEFAULT_LANGUAGE,
+    load: 'currentOnly',
 
-    // allow keys to be phrases having :, ., etc.
+    // Translation keys are explicit application identifiers and may contain punctuation.
     nsSeparator: false,
     keySeparator: false,
 
@@ -23,16 +23,17 @@ i18n
     detection: {
       order: ['cookie', 'navigator', 'localStorage', 'htmlTag', 'path', 'subdomain'],
       caches: ['cookie'],
-      cookieMinutes: 10080, // 7 days
+      lookupCookie: 'i18next',
+      cookieMinutes: 10080,
     },
 
     interpolation: {
-      escapeValue: false, // react already safes from xss
+      escapeValue: false,
     },
 
     react: {
       useSuspense: true,
-    }
+    },
   });
 
 export default i18n;

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -6,7 +6,7 @@
 
 - **[README.md](../README.md)**: Complete application documentation with all features
 - **[INSTALLATION.md](./INSTALLATION.md)**: Quick start guide for development
-- **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: Production-Deployment und Monitoring
+- **[ENTERPRISE_DEPLOYMENT.md](./ENTERPRISE_DEPLOYMENT.md)**: Production deployment and monitoring
 
 ## Overview
 
@@ -62,6 +62,27 @@ GET /api/admin/status
 }
 ```
 
+
+### Update Translation Dictionary
+
+Creates or replaces a translation dictionary for a built-in or custom language. Requires an authenticated admin session.
+
+```http
+PUT /api/admin/translations/{languageCode}
+Content-Type: application/json
+
+{
+  "loading_app": "Loading application...",
+  "translations": "Translations"
+}
+```
+
+**Validation**
+
+- `languageCode` must use a BCP 47 style value.
+- The request body must be a JSON object with string keys and string values.
+- Empty string values are allowed to make missing translations visible in the admin UI.
+
 ### Logout
 
 ```http
@@ -104,6 +125,46 @@ Content-Type: application/json
     "infoText": "This section has been moved to our new articles area.",
     "redirectType": "partial"
   }
+}
+```
+
+
+### Translation Languages
+
+Lists the built-in and manually added UI languages. This endpoint is public so the language switch can render before admin authentication.
+
+```http
+GET /api/translations/languages
+```
+
+**Response**
+
+```json
+{
+  "languages": [
+    { "code": "en", "nativeName": "English", "englishName": "English", "isBuiltIn": true },
+    { "code": "pt-br", "nativeName": "PT-BR", "englishName": "PT-BR", "isBuiltIn": false }
+  ]
+}
+```
+
+### Translation Dictionary
+
+Returns the requested language dictionary. Non-English dictionaries are merged with English fallback keys so the UI always has a complete response.
+
+```http
+GET /api/translations/{languageCode}
+```
+
+**Notes**
+
+- `languageCode` must use a BCP 47 style value such as `en`, `de`, `fr-ca`, or `pt-br`.
+- English (`en`) is the default and fallback language.
+
+```json
+{
+  "loading_app": "Loading application...",
+  "translations": "Translations"
 }
 ```
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,9 +1,9 @@
-# SmartRedirect Suite - Architektur-Overview
+# SmartRedirect Suite - Architecture Overview
 
 The application has a modular structure and clearly separates frontend, backend and shared types.
 
 ## Components
-- **client/**: React 18 + TypeScript frontend, bundled with Vite.
+- **client/**: React 19 + TypeScript frontend, bundled with Vite.
 - **server/**: Express-based backend with file storage and session handling.
 - **shared/**: Shared TypeScript types and validation schemes.
 
@@ -14,3 +14,7 @@ The application has a modular structure and clearly separates frontend, backend 
 4. `shared/` provides type definitions and Zod schemas for both sides.
 
 The architecture enables high-performance processing of over 100,000 rules through intelligent caching and optimized data structures.
+
+## Internationalization
+
+The frontend initializes i18next with English as the fallback language, browser-language detection, and cookie caching for explicit language-switch choices. Translation dictionaries are loaded from `/api/translations/{languageCode}` so administrators can update UI copy without rebuilding the application. The backend stores dictionaries in the `Translation` table, seeds the built-in languages (`en`, `de`, `it`, `es`, `fr`), validates custom language codes, and merges missing non-English keys with English fallback values.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:../vite.config",
     "start": "cross-env NODE_ENV=production node dist/index.js",
-    "test:unit": "tsx tests/shared/appMetadata.test.ts && tsx tests/client/url-utils.test.ts && tsx tests/shared/url-trace.test.ts",
+    "test:unit": "tsx tests/shared/appMetadata.test.ts && tsx tests/shared/i18n.test.ts && tsx tests/client/url-utils.test.ts && tsx tests/shared/url-trace.test.ts",
     "test": "npm run test:unit && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
     "check": "echo 'Skipping type check'"
   },
@@ -88,7 +88,7 @@
     "tsx": "^4.21.0",
     "uvu": "^0.5.6"
   },
-  "description": "SmartRedirect Suite ist eine Web-Anwendung zur zentralen Verwaltung von URL‑Migrationen zwischen alter und neuer Domain. Typischer Use Case: Migration von SharePoint On-Premises zu SharePoint Online, wenn sich Domain und Pfadstruktur ändern. Die App weist Nutzer auf veraltete Links hin und kann automatisch auf neue Ziele weiterleiten.",
+  "description": "SmartRedirect Suite is a web application for centrally managing URL migrations between legacy and target domains. Typical use case: migrations from SharePoint On-Premises to SharePoint Online where domains and path structures change. The app notifies users about outdated links and can automatically redirect them to new destinations.",
   "main": "index.js",
   "directories": {
     "doc": "docs",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -20,6 +20,7 @@ import path from "path";
 import { findMatchingRule } from "@shared/ruleMatching";
 import { RULE_MATCHING_CONFIG } from "@shared/constants";
 import { APPLICATION_METADATA } from "@shared/appMetadata";
+import { assertValidLanguageCode, createLanguageOptions, sanitizeTranslationPayload } from "@shared/i18n";
 import { ImportExportService } from "./import-export";
 import multer from 'multer';
 import fs from 'fs';
@@ -424,23 +425,38 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Check admin authentication status
 
   // Translations
-  app.get("/api/translations/:lang", async (req, res) => {
+  app.get("/api/translations/languages", async (_req, res) => {
     try {
-      const data = await storage.getTranslation(req.params.lang);
-      res.json(data);
+      const languageCodes = await storage.listTranslationLanguages();
+      res.json({ languages: createLanguageOptions(languageCodes) });
     } catch (error) {
-      console.error('Error fetching translations:', error);
-      res.status(500).json({ error: 'Failed to fetch translations' });
+      console.error('Error fetching translation languages:', error);
+      res.status(500).json({ error: 'Failed to fetch translation languages' });
     }
   });
 
-  app.put("/api/admin/translations/:lang", requireAuth, express.json(), async (req, res) => {
+  app.get("/api/translations/:lang", async (req, res) => {
     try {
-      await storage.updateTranslation(req.params.lang, req.body);
-      res.json({ message: 'Translations updated successfully' });
+      const languageCode = assertValidLanguageCode(req.params.lang);
+      const data = await storage.getTranslation(languageCode);
+      res.json(data);
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to fetch translations';
+      console.error('Error fetching translations:', error);
+      res.status(message.includes('Language code') ? 400 : 500).json({ error: message });
+    }
+  });
+
+  app.put("/api/admin/translations/:lang", requireAuth, express.json({ limit: '1mb' }), async (req, res) => {
+    try {
+      const languageCode = assertValidLanguageCode(req.params.lang);
+      const translationData = sanitizeTranslationPayload(req.body);
+      await storage.updateTranslation(languageCode, translationData);
+      res.json({ message: 'Translations updated successfully', language: languageCode });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update translations';
       console.error('Error updating translations:', error);
-      res.status(500).json({ error: 'Failed to update translations' });
+      res.status(message.includes('Language code') || message.includes('Translation') ? 400 : 500).json({ error: message });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -13,6 +13,7 @@ import type {
 import { urlUtils } from "@shared/utils";
 import { ProcessedUrlRule, RuleMatchingConfig, preprocessRule } from "@shared/ruleMatching";
 import { RULE_MATCHING_CONFIG } from "@shared/constants";
+import { BUILT_IN_LANGUAGES, DEFAULT_LANGUAGE, assertValidLanguageCode, mergeTranslationDictionaries, sanitizeTranslationPayload } from "@shared/i18n";
 import { sequelize, initDb, UrlRuleModel, UrlTrackingModel, GeneralSettingsModel, TranslationModel } from "./db";
 import { Op } from "sequelize";
 
@@ -153,6 +154,7 @@ export interface IStorage {
   forceCacheRebuild(): Promise<void>;
   // Translations
   getTranslation(lang: string): Promise<Record<string, string>>;
+  listTranslationLanguages(): Promise<string[]>;
   updateTranslation(lang: string, data: Record<string, string>): Promise<void>;
 
 }
@@ -200,15 +202,39 @@ export class FileStorage implements IStorage {
 
   // Translations
   async getTranslation(lang: string): Promise<Record<string, string>> {
-    const record = await TranslationModel.findByPk(lang);
-    if (!record) {
-      return {};
+    const normalizedLanguageCode = assertValidLanguageCode(lang);
+    const englishRecord = await TranslationModel.findByPk(DEFAULT_LANGUAGE);
+    const baseLanguageCode = normalizedLanguageCode.split('-')[0];
+    const requestedRecord =
+      (await TranslationModel.findByPk(normalizedLanguageCode)) ||
+      (baseLanguageCode !== normalizedLanguageCode ? await TranslationModel.findByPk(baseLanguageCode) : null);
+    const englishTranslations = (englishRecord?.get('data') as Record<string, string> | undefined) || {};
+    const requestedTranslations = (requestedRecord?.get('data') as Record<string, string> | undefined) || {};
+
+    if (normalizedLanguageCode === DEFAULT_LANGUAGE) {
+      return englishTranslations;
     }
-    return record.get('data') as Record<string, string>;
+
+    return mergeTranslationDictionaries(englishTranslations, requestedTranslations);
+  }
+
+  async listTranslationLanguages(): Promise<string[]> {
+    const records = await TranslationModel.findAll({ attributes: ['lang'] });
+    const languageCodes = records
+      .map((record) => record.get('lang') as string)
+      .filter(Boolean);
+
+    return Array.from(new Set([
+      ...BUILT_IN_LANGUAGES.map((language) => language.code),
+      ...languageCodes,
+    ])).sort();
   }
 
   async updateTranslation(lang: string, data: Record<string, string>): Promise<void> {
-    await TranslationModel.upsert({ lang, data });
+    const normalizedLanguageCode = assertValidLanguageCode(lang);
+    const sanitizedTranslationData = sanitizeTranslationPayload(data);
+
+    await TranslationModel.upsert({ lang: normalizedLanguageCode, data: sanitizedTranslationData });
   }
 
   private async initTranslations() {
@@ -3701,9 +3727,19 @@ export class FileStorage implements IStorage {
 };
 
     for (const [lang, data] of Object.entries(defaultTranslations)) {
-      const existing = await TranslationModel.findByPk(lang);
+      const normalizedLanguageCode = assertValidLanguageCode(lang);
+      const existing = await TranslationModel.findByPk(normalizedLanguageCode);
+
       if (!existing) {
-        await TranslationModel.create({ lang, data });
+        await TranslationModel.create({ lang: normalizedLanguageCode, data });
+        continue;
+      }
+
+      const existingData = existing.get('data') as Record<string, string>;
+      const mergedData = mergeTranslationDictionaries(data, existingData);
+
+      if (Object.keys(mergedData).length !== Object.keys(existingData).length) {
+        await existing.update({ data: mergedData });
       }
     }
   }

--- a/shared/i18n.ts
+++ b/shared/i18n.ts
@@ -1,0 +1,123 @@
+export const DEFAULT_LANGUAGE = "en";
+
+export const BUILT_IN_LANGUAGES = [
+  { code: "en", nativeName: "English", englishName: "English" },
+  { code: "de", nativeName: "Deutsch", englishName: "German" },
+  { code: "it", nativeName: "Italiano", englishName: "Italian" },
+  { code: "es", nativeName: "Español", englishName: "Spanish" },
+  { code: "fr", nativeName: "Français", englishName: "French" },
+] as const;
+
+export type BuiltInLanguageCode = (typeof BUILT_IN_LANGUAGES)[number]["code"];
+
+export type LanguageOption = {
+  code: string;
+  nativeName: string;
+  englishName: string;
+  isBuiltIn: boolean;
+};
+
+const BUILT_IN_LANGUAGE_MAP = new Map(
+  BUILT_IN_LANGUAGES.map((language) => [language.code, language]),
+);
+
+const LANGUAGE_CODE_PATTERN = /^[a-z]{2,3}(?:-[a-z0-9]{2,8}){0,2}$/;
+
+export function normalizeLanguageCode(languageCode: string): string {
+  return languageCode.trim().replace(/_/g, "-").toLowerCase();
+}
+
+export function isValidLanguageCode(languageCode: string): boolean {
+  return LANGUAGE_CODE_PATTERN.test(normalizeLanguageCode(languageCode));
+}
+
+export function assertValidLanguageCode(languageCode: string): string {
+  const normalizedLanguageCode = normalizeLanguageCode(languageCode);
+
+  if (!isValidLanguageCode(normalizedLanguageCode)) {
+    throw new Error(
+      "Language code must use a BCP 47 style value such as en, de, fr-ca, or pt-br.",
+    );
+  }
+
+  return normalizedLanguageCode;
+}
+
+export function createLanguageOption(languageCode: string): LanguageOption {
+  const normalizedLanguageCode = assertValidLanguageCode(languageCode);
+  const builtInLanguage = BUILT_IN_LANGUAGE_MAP.get(normalizedLanguageCode);
+
+  if (builtInLanguage) {
+    return {
+      code: builtInLanguage.code,
+      nativeName: builtInLanguage.nativeName,
+      englishName: builtInLanguage.englishName,
+      isBuiltIn: true,
+    };
+  }
+
+  const displayCode = normalizedLanguageCode.toUpperCase();
+
+  return {
+    code: normalizedLanguageCode,
+    nativeName: displayCode,
+    englishName: displayCode,
+    isBuiltIn: false,
+  };
+}
+
+export function createLanguageOptions(languageCodes: string[]): LanguageOption[] {
+  const languageCodeSet = new Set<string>([
+    ...BUILT_IN_LANGUAGES.map((language) => language.code),
+    ...languageCodes.map(normalizeLanguageCode).filter(isValidLanguageCode),
+  ]);
+
+  return Array.from(languageCodeSet)
+    .map(createLanguageOption)
+    .sort((leftLanguage, rightLanguage) => {
+      if (leftLanguage.code === DEFAULT_LANGUAGE) return -1;
+      if (rightLanguage.code === DEFAULT_LANGUAGE) return 1;
+
+      if (leftLanguage.isBuiltIn !== rightLanguage.isBuiltIn) {
+        return leftLanguage.isBuiltIn ? -1 : 1;
+      }
+
+      return leftLanguage.englishName.localeCompare(rightLanguage.englishName);
+    });
+}
+
+export function sanitizeTranslationPayload(
+  translationData: unknown,
+): Record<string, string> {
+  if (!translationData || typeof translationData !== "object" || Array.isArray(translationData)) {
+    throw new Error("Translation payload must be an object of string keys and string values.");
+  }
+
+  return Object.entries(translationData).reduce<Record<string, string>>(
+    (sanitizedTranslations, [rawKey, rawValue]) => {
+      const translationKey = rawKey.trim();
+
+      if (!translationKey) {
+        return sanitizedTranslations;
+      }
+
+      if (typeof rawValue !== "string") {
+        throw new Error(`Translation value for key '${translationKey}' must be a string.`);
+      }
+
+      sanitizedTranslations[translationKey] = rawValue;
+      return sanitizedTranslations;
+    },
+    {},
+  );
+}
+
+export function mergeTranslationDictionaries(
+  baseTranslations: Record<string, string>,
+  customTranslations: Record<string, string>,
+): Record<string, string> {
+  return {
+    ...baseTranslations,
+    ...customTranslations,
+  };
+}

--- a/tests/shared/i18n.test.ts
+++ b/tests/shared/i18n.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_LANGUAGE,
+  assertValidLanguageCode,
+  createLanguageOptions,
+  mergeTranslationDictionaries,
+  sanitizeTranslationPayload,
+} from '../../shared/i18n';
+
+(() => {
+  assert.equal(DEFAULT_LANGUAGE, 'en', 'English must remain the default language');
+
+  assert.equal(assertValidLanguageCode('PT_br'), 'pt-br');
+  assert.throws(
+    () => assertValidLanguageCode('../en'),
+    /Language code must use a BCP 47 style value/,
+    'Path-like language codes must be rejected',
+  );
+
+  assert.deepEqual(
+    sanitizeTranslationPayload({ ' title ': 'Welcome', empty: '', count: '5' }),
+    { title: 'Welcome', empty: '', count: '5' },
+    'Payload sanitization trims keys and preserves string values',
+  );
+  assert.throws(
+    () => sanitizeTranslationPayload({ title: 42 }),
+    /must be a string/,
+    'Non-string values must be rejected before persistence',
+  );
+
+  assert.deepEqual(
+    mergeTranslationDictionaries({ title: 'English title', body: 'English body' }, { title: 'Custom title' }),
+    { title: 'Custom title', body: 'English body' },
+    'Custom translations override English while retaining fallback keys',
+  );
+
+  const languageCodes = createLanguageOptions(['de', 'pt-br', 'en', '../en']);
+  assert.equal(languageCodes[0].code, 'en', 'English should be first in language selectors');
+  assert.ok(languageCodes.some((language) => language.code === 'pt-br' && !language.isBuiltIn));
+
+  console.log('i18n helper tests passed');
+})();


### PR DESCRIPTION
### Motivation
- Enable full multi-language support across the UI (including Admin) with English as the canonical default and fallback to support international markets.
- Provide administrators a safe, discoverable way to edit and extend translations from the Admin area without rebuilding the app. 
- Harden language handling using BCP‑47 validation and sensible fallbacks (region → base language → English) and persist explicit user choices in a cookie for predictable UX.

### Description
- Added shared i18n utilities in `shared/i18n.ts` for default language metadata, BCP‑47 normalization/validation, language option creation, payload sanitization, and dictionary merging. 
- Extended storage and DB handling to seed built‑in languages, return merged dictionaries (English fallback + custom), list available languages, and validate/sanitize updates (`server/storage.ts`, `server/db.ts`).
- Exposed new/updated endpoints: `GET /api/translations/languages`, `GET /api/translations/{lang}`, and `PUT /api/admin/translations/{lang}` with input validation, size limits and clear error semantics (`server/routes.ts`).
- Updated client i18n initialization to use English fallback, browser detection and cookie caching, moved load behavior to `currentOnly` and point to backend dictionaries (`client/src/i18n.ts`).
- Reworked `LanguageSwitch` to fetch available languages from the backend and fall back to base/English when needed (`client/src/components/LanguageSwitch.tsx`).
- Rebuilt Admin `TranslationManager` to list languages, add custom BCP‑47 languages, show missing keys against English fallback, edit/save/delete keys, search across key/value/fallback, and provide user feedback (`client/src/components/admin/TranslationManager.tsx`).
- Translated and updated user docs/specs to reflect the i18n behavior and admin workflows (`README.md`, `docs/API_DOCUMENTATION.md`, `docs/ARCHITECTURE_OVERVIEW.md`).
- Added unit tests for i18n helpers and integrated the test into `test:unit` (`tests/shared/i18n.test.ts`, `package.json`).

### Testing
- Unit tests: `npm run test:unit` (includes `tests/shared/i18n.test.ts`, `tests/shared/appMetadata.test.ts`, client/url-utils and url-trace tests) passed in this environment. ✅
- Integration smoke: early integration checks executed and several integration tests (rule matching / url-transformation related) ran and passed before the run hit environment limits. ✅
- Build: `npm run build` could not complete in this constrained environment due to Rollup failing to resolve some i18next/react-i18next artifacts in the local `node_modules` (environment/network constraints), so a full production build was not validated here. ⚠️
- Full test run: `npm run test` started and unit tests completed, but later integration steps require a complete `node_modules` (not available in this environment) and therefore could not fully complete here. ⚠️
- Security scan: `npm audit` was blocked by registry 403 responses from the environment when calling the audit endpoint. ⚠️

Notes / assumptions (operational): English remains the canonical fallback; region-specific codes (e.g. `de-DE`) fall back to base `de` when an exact dictionary is not present; custom languages must be valid BCP‑47 strings; administrators can intentionally save empty strings to surface missing translations in the UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f73ee72483318904afa38f952984)