### PR TITLE
feat: persist logos in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Fehler werden detailliert auf Deutsch ausgegeben; bei Validierungsfehlern werden
 
 ## Datenverwaltung
 
-Standardmäßig nutzt SmartRedirect Suite eine SQLite-Datenbank unter `data/database.sqlite`. Bestehende JSON-Dateien aus älteren Versionen (`data/rules.json`, `data/settings.json`, `data/tracking.json`) werden beim Start einmalig in die Datenbank migriert und anschließend als `.bak` gesichert. Admin-Sessions bleiben dateibasiert unter `data/sessions/`.
+Standardmäßig nutzt SmartRedirect Suite eine SQLite-Datenbank unter `data/database.sqlite`. Bestehende JSON-Dateien aus älteren Versionen (`data/rules.json`, `data/settings.json`, `data/tracking.json`) werden beim Start einmalig in die Datenbank migriert und anschließend als `.bak` gesichert. Bereits referenzierte Logo-Dateien aus `data/uploads` werden danach automatisch als Datenbank-Assets übernommen; `headerLogoUrl` verweist anschließend auf `/api/logo/:id`. Admin-Sessions bleiben dateibasiert unter `data/sessions/`.
 
 Für produktive Setups kann die Datenbank über `DB_DIALECT` auf `postgres`/`postgresql`, `mariadb` oder `mysql` umgestellt werden. Die Variablen `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` und optional `DB_SSL=true` steuern die Verbindung.
 

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -149,7 +149,7 @@ GET /api/admin/settings
   "id": "settings_uuid",
   "headerTitle": "SmartRedirect Suite",
   "headerIcon": "ArrowRightLeft",
-  "headerLogoUrl": "/objects/uploads/logo.png",
+  "headerLogoUrl": "/api/logo/6f018c91-6b99-4d77-9d44-c5ee1a9f5c6a",
   "mainTitle": "Outdated Link Detected",
   "mainDescription": "You are using an outdated link...",
   "alertIcon": "AlertTriangle",
@@ -498,22 +498,29 @@ Content-Type: application/json
 
 ```http
 POST /api/admin/logo/upload
-Content-Type: application/json
-
-{
-  "filename": "company-logo.png",
-  "contentType": "image/png"
-}
+Content-Type: multipart/form-data
 ```
+
+Form field: `file` (JPEG, PNG, GIF, WebP or SVG; max. 5 MB). The server stores the image bytes in the configured database and removes the temporary upload file after the database write succeeds.
 
 **Response**
 
 ```json
 {
-  "uploadURL": "https://storage.googleapis.com/bucket/signed-upload-url",
-  "fileId": "upload_uuid"
+  "uploadURL": "/api/logo/6f018c91-6b99-4d77-9d44-c5ee1a9f5c6a",
+  "filename": "company-logo.png",
+  "originalName": "company-logo.png",
+  "fileId": "6f018c91-6b99-4d77-9d44-c5ee1a9f5c6a"
 }
 ```
+
+#### Read Logo
+
+```http
+GET /api/logo/:id
+```
+
+Public endpoint used by `headerLogoUrl`. Returns the image bytes with the stored content type and long-lived immutable caching headers.
 
 #### Set Logo
 
@@ -522,7 +529,7 @@ PUT /api/admin/logo
 Content-Type: application/json
 
 {
-  "logoUrl": "https://storage.googleapis.com/bucket/uploads/logo.png"
+  "logoUrl": "/api/logo/6f018c91-6b99-4d77-9d44-c5ee1a9f5c6a"
 }
 ```
 
@@ -531,7 +538,7 @@ Content-Type: application/json
 ```json
 {
   "success": true,
-  "logoPath": "/objects/uploads/logo.png"
+  "logoPath": "/api/logo/6f018c91-6b99-4d77-9d44-c5ee1a9f5c6a"
 }
 ```
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -11,8 +11,9 @@ Die Anwendung ist modular aufgebaut und trennt klar zwischen Frontend, Backend u
 1. Anfragen erreichen das `server/`-Modul.
 2. Der Server initialisiert den Datenbankadapter aus den `DB_*`-Umgebungsvariablen. Standard ist SQLite unter `data/database.sqlite`; `postgres`/`postgresql`, `mariadb` und `mysql` sind über dieselbe Storage-Schnittstelle nutzbar.
 3. Bestehende JSON-Dateien (`rules.json`, `settings.json`, `tracking.json`) werden beim Start einmalig importiert und danach als `.bak` gesichert.
-4. Der Server prüft Regeln gegen einen **In-Memory Cache**, der aus der Datenbank aufgebaut und nach Regel-Importen/-Änderungen invalidiert wird, um I/O-Latenz zu vermeiden.
-5. Validierte Daten werden an das `client/`-Frontend ausgeliefert.
-6. `shared/` stellt Typdefinitionen und Zod-Schemas für beide Seiten bereit.
+4. Danach migriert der Server vorhandene Logo-Referenzen aus `/uploads/...` chronologisch korrekt in die Datenbank und aktualisiert `headerLogoUrl` auf `/api/logo/:id`, damit alte Installationen ohne manuellen Eingriff weiterlaufen.
+5. Der Server prüft Regeln gegen einen **In-Memory Cache**, der aus der Datenbank aufgebaut und nach Regel-Importen/-Änderungen invalidiert wird, um I/O-Latenz zu vermeiden.
+6. Validierte Daten werden an das `client/`-Frontend ausgeliefert.
+7. `shared/` stellt Typdefinitionen und Zod-Schemas für beide Seiten bereit.
 
 Die Architektur ermöglicht die hochperformante Verarbeitung von über 100.000 Regeln durch intelligentes Caching und optimierte Datenstrukturen.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:../vite.config",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "test:unit": "tsx tests/shared/appMetadata.test.ts && tsx tests/client/url-utils.test.ts && tsx tests/shared/url-trace.test.ts",
-    "test": "npm run test:unit && tsx tests/integration/database-adapter.test.ts && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
+    "test": "npm run test:unit && tsx tests/integration/database-adapter.test.ts && tsx tests/integration/logo-db-storage.test.ts && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
     "check": "echo 'Skipping type check'"
   },
   "dependencies": {

--- a/server/db.ts
+++ b/server/db.ts
@@ -264,6 +264,38 @@ export const UrlTrackingModel = sequelize.define('UrlTracking', {
   ],
 });
 
+export const LogoAssetModel = sequelize.define('LogoAsset', {
+  id: {
+    type: DataTypes.TEXT,
+    primaryKey: true,
+  },
+  filename: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+  contentType: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+  data: {
+    type: DataTypes.BLOB('long'),
+    allowNull: false,
+  },
+  size: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  createdAt: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+}, {
+  ...modelOptions,
+  indexes: [
+    { fields: ['createdAt'] },
+  ],
+});
+
 export const GeneralSettingsModel = sequelize.define('GeneralSettings', {
   id: {
     type: DataTypes.TEXT,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1158,6 +1158,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/logo/:id", async (req, res) => {
+    try {
+      const logo = await storage.getLogoAsset(req.params.id);
+      if (!logo) {
+        res.status(404).json({ error: "Logo not found" });
+        return;
+      }
+
+      res.setHeader("Content-Type", logo.contentType);
+      res.setHeader("Content-Length", String(logo.size));
+      res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+      res.send(logo.data);
+    } catch (error) {
+      console.error("Logo read error:", error);
+      res.status(500).json({ error: "Failed to read logo" });
+    }
+  });
+
   app.post("/api/admin/logo/upload", requireAuth, upload.single('file'), async (req, res) => {
     try {
       if (!req.file) {
@@ -1165,19 +1183,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return;
       }
 
-      // Explicitly register file in cache (if optimization enabled)
-      localUploadService.registerFile(req.file.filename);
+      const uploadedFileBuffer = await fs.promises.readFile(req.file.path);
+      const logoAsset = await storage.createLogoAsset({
+        filename: req.file.originalname,
+        contentType: req.file.mimetype,
+        data: uploadedFileBuffer,
+      });
+      await fs.promises.unlink(req.file.path).catch((error) => {
+        console.warn("Temporary logo upload cleanup failed:", error);
+      });
 
-      const fileUrl = localUploadService.getFileUrl(req.file.filename);
-      console.log("File uploaded successfully:", fileUrl);
+      const fileUrl = `/api/logo/${logoAsset.id}`;
+      console.log("Logo uploaded to database successfully:", fileUrl);
 
       res.json({
         uploadURL: fileUrl,
-        filename: req.file.filename,
-        originalName: req.file.originalname
+        filename: logoAsset.filename,
+        originalName: req.file.originalname,
+        fileId: logoAsset.id,
       });
     } catch (error) {
-      console.error("Local file upload error:", error);
+      if (req.file?.path) {
+        await fs.promises.unlink(req.file.path).catch(() => undefined);
+      }
+      console.error("Database logo upload error:", error);
       res.status(500).json({ error: "Failed to upload file", details: error instanceof Error ? error.message : String(error) });
     }
   });
@@ -1198,24 +1227,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const currentSettings = await storage.getGeneralSettings();
       const oldLogoUrl = currentSettings.headerLogoUrl;
 
-      // If there's an old logo file, delete it before setting the new one
-      if (oldLogoUrl && oldLogoUrl.startsWith('/uploads/') && oldLogoUrl !== logoPath) {
-        const oldFilename = oldLogoUrl.replace('/uploads/', '');
-        const oldFileDeleted = localUploadService.deleteFile(oldFilename);
-        console.log(`Old logo file deletion attempt for ${oldFilename}:`, oldFileDeleted ? 'success' : 'failed');
-      }
-
       console.log("Logo update - current settings has headerLogoUrl:", !!currentSettings.headerLogoUrl);
 
       const updatedSettings = await storage.updateGeneralSettings({
         headerLogoUrl: logoPath,
       } as InsertGeneralSettings);
 
+      // Delete the replaced logo only after settings were updated successfully.
+      if (oldLogoUrl && oldLogoUrl !== updatedSettings.headerLogoUrl) {
+        if (oldLogoUrl.startsWith('/api/logo/')) {
+          const oldLogoId = oldLogoUrl.replace('/api/logo/', '');
+          const oldLogoDeleted = await storage.deleteLogoAsset(oldLogoId);
+          console.log(`Old database logo deletion attempt for ${oldLogoId}:`, oldLogoDeleted ? 'success' : 'not found');
+        } else if (oldLogoUrl.startsWith('/uploads/')) {
+          const oldFilename = oldLogoUrl.replace('/uploads/', '');
+          const oldFileDeleted = localUploadService.deleteFile(oldFilename);
+          console.log(`Old logo file deletion attempt for ${oldFilename}:`, oldFileDeleted ? 'success' : 'failed');
+        }
+      }
+
       console.log("Logo update - updated settings has headerLogoUrl:", !!updatedSettings.headerLogoUrl);
 
       res.json({
         success: true,
-        logoPath: logoPath,
+        logoPath: updatedSettings.headerLogoUrl,
         settings: updatedSettings
       });
     } catch (error) {
@@ -1241,17 +1276,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return;
       }
 
-      // Only try to delete the physical file if it's a local upload
-      if (logoUrl.startsWith('/uploads/')) {
+      // Remove the stored database asset or, for legacy installations, the old upload file.
+      if (logoUrl.startsWith('/api/logo/')) {
+        const logoId = logoUrl.replace('/api/logo/', '');
+        const logoDeleted = await storage.deleteLogoAsset(logoId);
+        console.log(`Database logo deletion attempt for ${logoId}:`, logoDeleted ? 'success' : 'not found');
+      } else if (logoUrl.startsWith('/uploads/')) {
         const filename = logoUrl.replace('/uploads/', '');
-        console.log(`Attempting to delete logo file: ${filename} from URL: ${logoUrl}`);
-        
-        // Try to delete the file - success or failure doesn't matter for the API response
-        // as the important thing is removing the logo URL from settings
+        console.log(`Attempting to delete legacy logo file: ${filename} from URL: ${logoUrl}`);
         const fileDeleted = localUploadService.deleteFile(filename);
-        console.log(`Logo file deletion attempt for ${filename}:`, fileDeleted ? 'success' : 'file not found (already deleted)');
+        console.log(`Legacy logo file deletion attempt for ${filename}:`, fileDeleted ? 'success' : 'file not found (already deleted)');
       } else {
-        console.log(`Logo URL is not a local file: ${logoUrl}`);
+        console.log(`Logo URL is not a local/database logo: ${logoUrl}`);
       }
 
       // Update settings to explicitly remove the logo URL by setting it to null

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -13,7 +13,7 @@ import type {
 import { urlUtils } from "@shared/utils";
 import { ProcessedUrlRule, RuleMatchingConfig, preprocessRule } from "@shared/ruleMatching";
 import { RULE_MATCHING_CONFIG } from "@shared/constants";
-import { sequelize, initDb, UrlRuleModel, UrlTrackingModel, GeneralSettingsModel } from "./db";
+import { sequelize, initDb, UrlRuleModel, UrlTrackingModel, GeneralSettingsModel, LogoAssetModel } from "./db";
 import { Op } from "sequelize";
 
 // Helper to ensure only relevant flags are stored
@@ -29,6 +29,23 @@ function sanitizeRuleFlags(rule: any): any {
 }
 
 const DATA_DIR = path.join(process.cwd(), "data");
+const LEGACY_UPLOAD_URL_PREFIX = "/uploads/";
+const DATABASE_LOGO_URL_PREFIX = "/api/logo/";
+
+export interface LogoAsset {
+  id: string;
+  filename: string;
+  contentType: string;
+  data: Buffer;
+  size: number;
+  createdAt: string;
+}
+
+export interface CreateLogoAssetInput {
+  filename: string;
+  contentType: string;
+  data: Buffer;
+}
 
 const URL_RULE_SORT_COLUMNS = new Set([
   "matcher",
@@ -182,6 +199,9 @@ export interface IStorage {
 
   // General Settings
   getGeneralSettings(): Promise<GeneralSettings>;
+  createLogoAsset(input: CreateLogoAssetInput): Promise<LogoAsset>;
+  getLogoAsset(id: string): Promise<LogoAsset | undefined>;
+  deleteLogoAsset(id: string): Promise<boolean>;
   updateGeneralSettings(
     settings: InsertGeneralSettings,
     replaceMode?: boolean,
@@ -251,6 +271,7 @@ export class FileStorage implements IStorage {
       try {
         await initDb();
         await this.migrateJsonToDb();
+        await this.migrateLegacyLogoReferences();
         this.dbInitialized = true;
         console.log('Database initialized successfully');
       } catch (err) {
@@ -259,6 +280,104 @@ export class FileStorage implements IStorage {
     })();
 
     return this.initPromise;
+  }
+
+  private getLegacyUploadDirectory(): string {
+    const configuredUploadPath = process.env.LOCAL_UPLOAD_PATH || './data/uploads';
+    return path.isAbsolute(configuredUploadPath)
+      ? configuredUploadPath
+      : path.resolve(process.cwd(), configuredUploadPath);
+  }
+
+  private getDatabaseLogoUrl(id: string): string {
+    return `${DATABASE_LOGO_URL_PREFIX}${id}`;
+  }
+
+  private getFilenameFromLegacyLogoUrl(logoUrl: string | null | undefined): string | undefined {
+    if (!logoUrl?.startsWith(LEGACY_UPLOAD_URL_PREFIX)) {
+      return undefined;
+    }
+
+    const filename = logoUrl.slice(LEGACY_UPLOAD_URL_PREFIX.length);
+    if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+      return undefined;
+    }
+
+    return filename;
+  }
+
+  private getContentTypeFromFilename(filename: string): string {
+    const extension = path.extname(filename).toLowerCase();
+    const contentTypes: Record<string, string> = {
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.png': 'image/png',
+      '.gif': 'image/gif',
+      '.webp': 'image/webp',
+      '.svg': 'image/svg+xml',
+    };
+
+    return contentTypes[extension] || 'application/octet-stream';
+  }
+
+  private async createLogoAssetFromLegacyUpload(legacyLogoUrl: string): Promise<LogoAsset | undefined> {
+    const filename = this.getFilenameFromLegacyLogoUrl(legacyLogoUrl);
+    if (!filename) {
+      return undefined;
+    }
+
+    const uploadDirectory = this.getLegacyUploadDirectory();
+    const legacyFilePath = path.resolve(uploadDirectory, filename);
+    if (!legacyFilePath.startsWith(uploadDirectory + path.sep)) {
+      return undefined;
+    }
+
+    try {
+      const data = await fs.readFile(legacyFilePath);
+      return this.createLogoAssetRecord({
+        filename,
+        contentType: this.getContentTypeFromFilename(filename),
+        data,
+      });
+    } catch (error) {
+      console.warn(`Could not migrate legacy logo file ${filename} to database:`, error);
+      return undefined;
+    }
+  }
+
+  private async migrateLegacyLogoReferences() {
+    const row = await GeneralSettingsModel.findOne();
+    if (!row) {
+      return;
+    }
+
+    let settings = row.getDataValue('data') as any;
+    if (typeof settings === 'string') {
+      try {
+        settings = JSON.parse(settings);
+      } catch {
+        return;
+      }
+    }
+
+    const legacyLogoUrl = settings?.headerLogoUrl;
+    if (!legacyLogoUrl?.startsWith(LEGACY_UPLOAD_URL_PREFIX)) {
+      return;
+    }
+
+    const migratedLogo = await this.createLogoAssetFromLegacyUpload(legacyLogoUrl);
+    if (!migratedLogo) {
+      return;
+    }
+
+    const migratedSettings = {
+      ...settings,
+      headerLogoUrl: this.getDatabaseLogoUrl(migratedLogo.id),
+      updatedAt: new Date().toISOString(),
+    };
+    await row.update({ data: migratedSettings } as any);
+    this.settingsCache = null;
+    console.log(`Migrated legacy logo ${legacyLogoUrl} into database asset ${migratedLogo.id}`);
   }
 
   private async migrateJsonToDb() {
@@ -1027,6 +1146,50 @@ export class FileStorage implements IStorage {
     return { imported, updated, errors: [] };
   }
 
+  private async createLogoAssetRecord(input: CreateLogoAssetInput): Promise<LogoAsset> {
+    const logoAsset: LogoAsset = {
+      id: randomUUID(),
+      filename: path.basename(input.filename),
+      contentType: input.contentType,
+      data: input.data,
+      size: input.data.length,
+      createdAt: new Date().toISOString(),
+    };
+
+    await LogoAssetModel.create(logoAsset as any);
+    return logoAsset;
+  }
+
+  async createLogoAsset(input: CreateLogoAssetInput): Promise<LogoAsset> {
+    await this.ensureDbReady();
+    return this.createLogoAssetRecord(input);
+  }
+
+  async getLogoAsset(id: string): Promise<LogoAsset | undefined> {
+    await this.ensureDbReady();
+
+    const row = await LogoAssetModel.findByPk(id);
+    if (!row) {
+      return undefined;
+    }
+
+    const json = row.toJSON() as any;
+    return {
+      id: json.id,
+      filename: json.filename,
+      contentType: json.contentType,
+      data: Buffer.isBuffer(json.data) ? json.data : Buffer.from(json.data),
+      size: json.size,
+      createdAt: json.createdAt,
+    };
+  }
+
+  async deleteLogoAsset(id: string): Promise<boolean> {
+    await this.ensureDbReady();
+    const deletedCount = await LogoAssetModel.destroy({ where: { id } });
+    return deletedCount > 0;
+  }
+
   async getGeneralSettings(): Promise<GeneralSettings> {
     await this.ensureDbReady();
     if (this.settingsCache) return this.settingsCache;
@@ -1168,6 +1331,13 @@ export class FileStorage implements IStorage {
           delete (settings as any)[key];
         }
       });
+    }
+
+    if (settings.headerLogoUrl?.startsWith(LEGACY_UPLOAD_URL_PREFIX)) {
+      const migratedLogo = await this.createLogoAssetFromLegacyUpload(settings.headerLogoUrl);
+      if (migratedLogo) {
+        settings.headerLogoUrl = this.getDatabaseLogoUrl(migratedLogo.id);
+      }
     }
 
     const row = await GeneralSettingsModel.findOne();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -239,8 +239,8 @@ export const baseGeneralSettingsSchema = z.object({
     .max(2000, "Logo-URL ist zu lang")
     .optional()
     .nullable()
-    .refine((val) => !val || val.startsWith('/objects/') || val.startsWith('/uploads/') || val.startsWith('http'), {
-      message: "Logo-URL muss eine gültige HTTP-URL, Object-Storage-Pfad oder lokaler Upload-Pfad sein",
+    .refine((val) => !val || val.startsWith('/api/logo/') || val.startsWith('/objects/') || val.startsWith('/uploads/') || val.startsWith('http'), {
+      message: "Logo-URL muss eine gültige HTTP-URL, Object-Storage-Pfad, Datenbank-Logo-URL oder lokaler Upload-Pfad sein",
     }),
   headerBackgroundColor: z.string()
     .regex(/^(#([0-9A-Fa-f]{3}){1,2}|[a-zA-Z]+)$/, "Invalid color format")

--- a/tests/integration/logo-db-storage.test.ts
+++ b/tests/integration/logo-db-storage.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+
+const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "srs-logo-db-"));
+process.chdir(tempDirectory);
+process.env.DB_DIALECT = "sqlite";
+process.env.DB_STORAGE = path.join(tempDirectory, "data", "logo.sqlite");
+process.env.LOCAL_UPLOAD_PATH = path.join(tempDirectory, "data", "uploads");
+
+const dataDirectory = path.join(tempDirectory, "data");
+const uploadDirectory = path.join(dataDirectory, "uploads");
+const legacyLogoFilename = "legacy-logo.svg";
+const legacyLogoContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><text>Logo</text></svg>');
+
+await fs.mkdir(uploadDirectory, { recursive: true });
+await fs.writeFile(path.join(uploadDirectory, legacyLogoFilename), legacyLogoContent);
+await fs.writeFile(
+  path.join(dataDirectory, "settings.json"),
+  JSON.stringify({
+    id: "11111111-1111-4111-8111-111111111111",
+    headerTitle: "Legacy Settings",
+    headerLogoUrl: `/uploads/${legacyLogoFilename}`,
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  }),
+);
+
+const dbModule = await import("../../server/db");
+const { storage } = await import("../../server/storage");
+const { registerRoutes } = await import("../../server/routes");
+
+async function runLogoDatabaseStorageTests() {
+  console.log("Running logo database storage tests...");
+
+  const migratedSettings = await storage.getGeneralSettings();
+  assert.match(
+    migratedSettings.headerLogoUrl ?? "",
+    /^\/api\/logo\/[0-9a-f-]+$/,
+    "Startup migration must rewrite legacy /uploads logo URLs to DB-backed /api/logo URLs",
+  );
+
+  await fs.access(path.join(dataDirectory, "settings.json.bak"));
+  assert.deepEqual(
+    await fs.readFile(path.join(uploadDirectory, legacyLogoFilename)),
+    legacyLogoContent,
+    "Startup migration must preserve the legacy logo file while DB-backed URLs roll out",
+  );
+
+  const logoId = migratedSettings.headerLogoUrl!.replace("/api/logo/", "");
+  const migratedLogo = await storage.getLogoAsset(logoId);
+  assert.ok(migratedLogo, "Migrated legacy logo must be available as a database asset");
+  assert.equal(migratedLogo.filename, legacyLogoFilename);
+  assert.equal(migratedLogo.contentType, "image/svg+xml");
+  assert.deepEqual(migratedLogo.data, legacyLogoContent);
+
+  const createdLogo = await storage.createLogoAsset({
+    filename: "uploaded.png",
+    contentType: "image/png",
+    data: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+  });
+  const updatedSettings = await storage.updateGeneralSettings({
+    headerLogoUrl: `/api/logo/${createdLogo.id}`,
+  } as any);
+  assert.equal(updatedSettings.headerLogoUrl, `/api/logo/${createdLogo.id}`);
+
+  const app = express();
+  app.use(express.json());
+  const server = await registerRoutes(app);
+
+  const response = await request(server).get(`/api/logo/${createdLogo.id}`);
+  assert.equal(response.status, 200);
+  assert.equal(response.headers["content-type"], "image/png");
+  assert.deepEqual(response.body, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+  const deleteResult = await storage.deleteLogoAsset(createdLogo.id);
+  assert.equal(deleteResult, true);
+  assert.equal(await storage.getLogoAsset(createdLogo.id), undefined);
+
+  server.close();
+  await dbModule.sequelize.close();
+  console.log("logo database storage tests passed");
+}
+
+runLogoDatabaseStorageTests().catch(async (error) => {
+  console.error(error);
+  await dbModule.sequelize.close().catch(() => undefined);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Provide a robust, backwards-compatible way to store and serve admin-uploaded logos as first-class database assets instead of filesystem-only references.
- Ensure existing installations keep working: legacy `data/settings.json` and referenced files in `data/uploads` must be migrated automatically on startup (chronologically after JSON → DB migration) and preserve the original files for rollback.
- Avoid accidental data-loss during updates by deleting replaced logo assets only after the settings update succeeds.
- Keep API and schema consistent so `headerLogoUrl` can reference DB-backed logo URLs (`/api/logo/:id`) as well as legacy `/uploads/` and external HTTP/object-storage paths.

### Description

- Added a new Sequelize model `LogoAsset` to persist logo metadata and blob data in the DB and registered it in `server/db.ts`.
- Extended the storage interface and `FileStorage` (`server/storage.ts`) with `createLogoAsset`, `getLogoAsset`, and `deleteLogoAsset` methods plus internal helpers to migrate legacy `/uploads/...` files into DB assets.
- Startup ordering: after `migrateJsonToDb()` runs, `migrateLegacyLogoReferences()` runs to convert `headerLogoUrl` entries that point to `/uploads/...` into `/api/logo/:id` DB URLs while preserving the original upload file and writing a `.bak` for `settings.json`.
- Changed admin upload flow (`POST /api/admin/logo/upload`) to write uploaded image bytes into the DB, remove the temporary file, and return a DB URL `/api/logo/:id` and `fileId` in the response.
- Added public read endpoint `GET /api/logo/:id` to serve logo bytes with correct `Content-Type`, `Content-Length` and long-lived immutable caching headers.
- Updated `PUT /api/admin/logo` and `DELETE /api/admin/logo` flows to handle both DB-backed logos (`/api/logo/:id`) and legacy uploads (`/uploads/:file`) and to only delete the replaced asset after a successful settings update.
- Extended `shared` Zod schema to accept DB-logo URLs by allowing `/api/logo/` prefixes for `headerLogoUrl` and updated docs (`README.md`, `docs/API_DOCUMENTATION.md`, `docs/ARCHITECTURE_OVERVIEW.md`).
- Added an integration test `tests/integration/logo-db-storage.test.ts` that verifies startup migration of legacy logos, `.bak` creation, DB asset contents, public serving, update via settings, and deletion.

### Testing

- Ran unit tests with `npm run test:unit`, which passed (`tests/shared/appMetadata.test.ts`, `tests/client/url-utils.test.ts`, `tests/shared/url-trace.test.ts`).
- Built frontend and server with `npm run build`, which completed successfully (Vite emitted existing chunk-size warnings only). 
- Ran `npm run check` (project intentionally skips type-check in script), completed successfully.
- Created and wired an integration test `tests/integration/logo-db-storage.test.ts`; executing it in this environment failed because the test runner could not resolve `sequelize` due to missing local node modules and registry access returning `403 Forbidden` during dependency installation, therefore full integration execution could not be completed here.
- Notes: `npm audit` also could not run in this environment due to registry/audit endpoint `403` responses.

Files/areas changed (high level): `server/db.ts`, `server/storage.ts`, `server/routes.ts`, `shared/schema.ts`, `tests/integration/logo-db-storage.test.ts`, `docs/API_DOCUMENTATION.md`, `docs/ARCHITECTURE_OVERVIEW.md`, `README.md`, `package.json` (test script updated).

Edge assumptions: migration intentionally runs after JSON → DB import so legacy `settings.json` is backed up first; legacy upload files are preserved during migration to allow safe rollbacks; replaced logos are removed only after settings update success to avoid accidental removal on failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f967906c83318efb7307418b3e5c)