### PR TITLE
fix: resolve NextRelease merge conflicts (DB sessions, i18n, docs, CI & tests)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,20 @@ NODE_ENV=production
 # File Upload Configuration
 # Local file storage path for uploaded logo files
 LOCAL_UPLOAD_PATH=./data/uploads
+
+# Database Configuration
+# sqlite is the default. Use postgres/postgresql, mariadb, or mysql for external databases.
+DB_DIALECT=sqlite
+# SQLite file path; ignored for external databases.
+DB_STORAGE=./data/database.sqlite
+# External database settings (PostgreSQL/MariaDB/MySQL).
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_NAME=smartredirect
+# DB_USER=redirectuser
+# DB_PASSWORD=change-me
+# DB_SSL=false
+# DB_POOL_MAX=5
+# DB_POOL_MIN=0
+# DB_POOL_ACQUIRE_MS=30000
+# DB_POOL_IDLE_MS=10000

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,6 +34,8 @@ jobs:
             npm install --package-lock-only --ignore-scripts
           fi
       - run: npm ci
+      - name: Audit dependencies
+        run: npm audit --audit-level=low
       - run: npm test
       # Verify build works
       - run: npm run build
@@ -69,12 +71,14 @@ jobs:
             npm install --package-lock-only --ignore-scripts
           fi
       - run: npm ci
+      - name: Audit dependencies
+        run: npm audit --audit-level=low
 
       - name: Semantic Release
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         with:
-          semantic_version: 22
+          semantic_version: 25
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This version is always based on the latest dev build, resets every 24 hours and 
 - Central rule management with automatic URL detection
 - Controlled migrations and traceable domain changes
 - Productivity: Multi-select, import/export of rules
-- Admin panel with persistent session, customizable UI, and translation management
+- Admin panel with secure session handling, customizable UI, and translation management
 - Intelligent validation with overlap detection
 - Extensive statistics and URL tracking
 - Scalable architecture: Processing of over 100,000 rules and log entries without sacrificing performance
@@ -235,6 +235,7 @@ For "Partial" and "Full" (Wildcard) redirects, you can control how URL parameter
 ### Prerequisites
 
 - Node.js >= 22
+- npm >= 10.9.0
 
 Check the installation:
 
@@ -255,6 +256,8 @@ cd SmartRedirectSuite
 ```bash
 npm install
 ```
+
+> Note: CI also runs `npm audit --audit-level=low` so installed dependencies are checked for known vulnerabilities before tests, build, and release.
 
 ### 3. Create .env file
 
@@ -424,15 +427,14 @@ Errors are reported in detail in German; If there are validation errors, no chan
 
 ## Data management
 
-By default, JSON files in the `data/` directory are used:
+By default, SmartRedirect Suite uses a SQLite database at `data/database.sqlite`. Existing JSON files from older versions (`data/rules.json`, `data/settings.json`, `data/tracking.json`) are migrated once at startup and then backed up as `.bak` files.
 
-- `data/rules.json`, `data/settings.json`, `data/tracking.json`
-- `data/sessions/` for admin sessions
+Admin sessions are stored in the database and deliberately cleared on each server startup; old `data/sessions/*.json` files are deleted and not imported. Production setups can switch the database with `DB_DIALECT` to `postgres`/`postgresql`, `mariadb`, or `mysql`. `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, and optional `DB_SSL=true` configure external connections.
 
 ## Security
 
-- Persistent session authentication (7 days)
-- Secure cookies and file-based sessions
+- Session authentication with a 7-day cookie lifetime within a server lifecycle
+- Secure cookies and database-backed sessions
 - Password protected admin area
 - Brute force protection with IP blocking (configurable via `LOGIN_MAX_ATTEMPTS` and `LOGIN_BLOCK_DURATION_MS`)
 - XSS protection through React

--- a/docs/ADMIN_DOCUMENTATION.md
+++ b/docs/ADMIN_DOCUMENTATION.md
@@ -15,8 +15,8 @@ The admin area is accessible via the application's gear icon or by appending `?a
 - **Table resizing**: Column widths can be adjusted individually in the "Rules" view and the "Import preview". To do this, move the mouse to the right edge of a column heading until the cursor changes and drag the column to the desired width.
 
 ## Maintenance
-- Regular backups of the `data/` directories.
-- Clean up expired sessions under `data/sessions/`.
+- Regular backups of `data/database.sqlite` or the external PostgreSQL/MariaDB/MySQL database, plus the `data/` directory for uploads.
+- Admin sessions live in the same database, are cleared on every server start, and are also cleaned up automatically after expiry.
 - Monitor logs and performance metrics according to deployment guides.
 - **Rebuild cache**: The rule cache can be rebuilt manually in the admin area under "System & Data" > "Maintenance". This isn't usually necessary, but can help if you're having redirect issues after large imports or updates.
 

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -23,7 +23,7 @@ Development: http://localhost:5000/api
 
 ## Authentication
 
-The API uses session-based authentication for admin operations. All admin endpoints require a valid session.
+The API uses database-backed session authentication for admin operations. All admin endpoints require a valid session cookie.
 
 ### Login
 
@@ -197,7 +197,7 @@ Content-Type: application/json
 
 ### Get General Settings
 
-Retrieves public configuration settings for the migration interface.
+Retrieves public configuration settings for the migration interface. The API response remains a single settings object for compatibility.
 
 ```http
 GET /api/admin/settings
@@ -734,7 +734,7 @@ GET /api/health
   },
   "checks": {
     "filesystem": { "status": "ok", "responseTime": 2 },
-    "objectStorage": { "status": "ok", "responseTime": 45 },
+    "storage": { "status": "ok", "responseTime": 45 },
     "sessions": { "status": "ok", "responseTime": 1 }
   }
 }

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -4,17 +4,30 @@ The application has a modular structure and clearly separates frontend, backend 
 
 ## Components
 - **client/**: React 19 + TypeScript frontend, bundled with Vite.
-- **server/**: Express-based backend with file storage and session handling.
+- **server/**: Express-based backend with Sequelize database storage (SQLite by default, PostgreSQL/MariaDB/MySQL optional), rule cache, translation persistence, and database-backed session handling.
 - **shared/**: Shared TypeScript types and validation schemes.
 
 ## Process
 1. Requests reach the `server/` module.
-2. The server checks rules against an **in-memory cache** loaded from `data/rules.json` at startup to avoid I/O latency.
-3. Validated data is delivered to the `client/` frontend.
-4. `shared/` provides type definitions and Zod schemas for both sides.
+2. The server initializes the database adapter from the `DB_*` environment variables. SQLite uses `data/database.sqlite`; `postgres`/`postgresql`, `mariadb`, and `mysql` use the same storage interface.
+3. Existing JSON files (`rules.json`, `settings.json`, `tracking.json`) are imported once at startup and backed up as `.bak` files.
+4. The server checks rules against an **in-memory cache** built from the database and invalidated after rule imports or changes.
+5. Admin routes use Express Session with `DatabaseSessionStore`; expired sessions are pruned and all sessions are invalidated on startup.
+6. Validated data is delivered to the `client/` frontend.
+7. `shared/` provides type definitions and Zod schemas for both sides.
 
 The architecture enables high-performance processing of over 100,000 rules through intelligent caching and optimized data structures.
 
 ## Internationalization
 
 The frontend initializes i18next with English as the fallback language, browser-language detection, and cookie caching for explicit language-switch choices. Translation dictionaries are loaded from `/api/translations/{languageCode}` so administrators can update UI copy without rebuilding the application. The backend stores dictionaries in the `Translation` table, seeds the built-in languages (`en`, `de`, `it`, `es`, `fr`), validates custom language codes, and merges missing non-English keys with English fallback values.
+
+
+## Dependency maintenance notes
+
+`npm audit --audit-level=low` is part of CI so advisories in runtime and development dependencies stop pull requests before tests, build, and release. Local installations should use the npm version range declared in `package.json`.
+
+Known transitive deprecation notes remain for dependencies below and require architecture-level migrations rather than safe patch updates:
+
+- `dottie` is pulled in by Sequelize 6.x. Moving away from it requires a Sequelize 7 or ORM migration.
+- `prebuild-install` is pulled in by `sqlite3`. Replacing it requires validating a different SQLite driver or ORM dialect integration.

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -63,22 +63,26 @@ By default, SmartRedirect Suite uses an SQLite database (`database.sqlite`) loca
 
 | Variable | Description | Standard |
 |----------|-------------|---------|
-| `DB_DIALECT` | Database type: `sqlite`, `postgres`, `mysql` or `mariadb` | `sqlite` |
+| `DB_DIALECT` | Database type: `sqlite`, `postgres`/`postgresql`, `mysql` or `mariadb` | `sqlite` |
 | `DB_HOST` | Database hostname. | `localhost` |
 | `DB_PORT` | Port of the database (e.g. 5432 for Postgres, 3306 for MariaDB). | `5432` / `3306` |
 | `DB_NAME` | Name of the database. | `smartredirect` |
 | `DB_USER` | Username for the database. | `root` |
 | `DB_PASSWORD` | Password for the database. | |
+| `DB_STORAGE` | SQLite file path when `DB_DIALECT=sqlite` is set. | `/app/data/database.sqlite` |
+| `DB_SSL` | Enables TLS for PostgreSQL/MariaDB/MySQL connections (`true`/`false`). | `false` |
+| `DB_POOL_MAX` | Maximum number of concurrent DB connections in the Sequelize pool. | `5` |
+| `DB_POOL_MIN` | Minimum number of open DB connections in the Sequelize pool. | `0` |
 
 There are `docker-compose.mariadb.yml` and `docker-compose.postgresql.yml` available as templates in the repository.
 
 ## 💾 Data persistence
 
-The SmartRedirect Suite uses file-based storage for rules, settings and sessions. To avoid data loss when restarting the container, volumes **must** be mounted.
+The SmartRedirect Suite uses SQLite by default for rules, settings, tracking, translations, and admin sessions. To avoid data loss when restarting the container, volumes **must** be mounted.
 
 | Path in the container | Description |
 |-------------------|-------------|
-| `/app/data` | Stores `rules.json`, `settings.json` and admin sessions. |
+| `/app/data` | Stores `database.sqlite`, migrated JSON backups (`*.bak`) and uploads. Active admin sessions are stored in the database but cleared on every server start. |
 
 **Note about permissions:**
 Make sure the mounted directories on the host are writable. Since the Dockerfile runs as `root` by default, standard permissions usually work without any problems.
@@ -130,7 +134,7 @@ docker-compose logs -f
 ## 🔒 Production best practices
 
 1. **Change default credentials:** Always set a strong `ADMIN_PASSWORD`.
-2. **Session Secret:** Set a fixed `SESSION_SECRET` if you want admin sessions to remain valid even after a container restart. Without this variable, a new security key is generated every time you start, which invalidates all existing logins.
+2. **Session Secret:** Set a fixed `SESSION_SECRET` so session cookies remain stably signed during runtime. Admin sessions are deliberately cleared at server startup; without this variable, cookie signatures also change at every start.
 3. **Use Reverse Proxy:** Do not expose port 5000 directly to the Internet. Use Nginx, Traefik or Caddy for SSL termination (HTTPS) and forward requests to the container.
     *   Set the `X-Forwarded-Proto` header in the proxy to make the app recognize HTTPS.
 3. **Backups:** Regularly back up the `./data` directory on the host system.

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -17,8 +17,8 @@ This document provides comprehensive deployment instructions for the enterprise-
 ### Technology Stack
 - **Frontend**: React 18 + TypeScript + Vite
 - **Backend**: Node.js + Express + TypeScript
-- **Data Storage**: File-based JSON storage
-- **Session Management**: Express-session with file-based persistence
+- **Data Storage**: Sequelize-backed database storage (SQLite by default; PostgreSQL/MariaDB/MySQL optional)
+- **Session Management**: Express-session with database-backed storage and startup invalidation
 - **Object Storage**: Google Cloud Storage integration
 - **Performance**: Virtual scrolling, memory monitoring, and comprehensive in-memory caching for rules and settings
 
@@ -488,11 +488,11 @@ artillery run load-test.yml
 
 3. **Session Issues**
    ```bash
-   # Check session storage
-   ls -la data/sessions/
+   # Check database connectivity; AdminSessions stores active sessions
+   sqlite3 data/database.sqlite "select count(*) from AdminSessions;"
    
-   # Clear expired sessions
-   find data/sessions/ -name "*.json" -mtime +7 -delete
+   # Expired sessions are removed automatically; AdminSessions is cleared on startup.
+   sqlite3 data/database.sqlite "delete from AdminSessions;"
    ```
 
 4. **Object Storage Issues**

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -12,18 +12,21 @@
 ## 1. Check requirements
 
 ```bash
-# Node.js Version prüfen (benötigt: v18+)
+# Check Node.js version (required: v22+)
 node --version
 
-# npm Version prüfen
+# Check npm version (required: v10.9+)
 npm --version
 ```
 
 ## 2. Installation
 
 ```bash
-# Dependencies installieren
+# Install dependencies
 npm install
+
+# Check installed dependencies for known vulnerabilities
+npm audit --audit-level=low
 
 # Optionale Umgebungsvariablen konfigurieren
 cp .env.example .env

--- a/docs/OPENSHIFT_DEPLOYMENT.md
+++ b/docs/OPENSHIFT_DEPLOYMENT.md
@@ -11,7 +11,7 @@
 ## Overview
 
 This guide describes how to deploy the URL Migration Tool application on OpenShift with persistent data storage and production-grade configuration.
-The application stores all data exclusively in the file system; a database is not used.
+The application stores configuration, tracking, translations, and admin sessions in the configured database (SQLite by default under `/app/data/database.sqlite`); uploads continue to use the `/app/data` volume. Admin sessions are cleared on every server start.
 
 ## Requirements
 
@@ -53,11 +53,11 @@ oc adm policy add-scc-to-user anyuid -z smartredirect-sa
 
 ## 2. Configure persistent storage
 
-The application stores configurations, sessions and uploads exclusively in the file system. A database is not required.
+The application stores configuration, tracking, translations, and admin sessions in the configured database (SQLite by default under `/app/data/database.sqlite`); uploads continue to use the `/app/data` volume. Admin sessions are cleared on every server start.
 
 ### Create persistent volume claims
 
-**Important**: The application only requires **one** persistent volume for `/app/data`. By default, uploads are stored in `/app/data/uploads` and sessions in `/app/data/sessions`.
+**Important**: With SQLite, the application only requires **one** persistent volume for `/app/data`. Uploads are stored in `/app/data/uploads`; active admin sessions are stored in the database, and old `data/sessions/*.json` files are deleted at startup instead of imported.
 
 ```yaml
 # Erstelle pvc-data.yaml
@@ -123,7 +123,7 @@ oc create secret tls smartredirect-tls \
 
 **Unsupported variables** (hard-coded in the application):
 - `DATA_PATH` - Data is always stored in `./data`
-- `SESSION_PATH` - Sessions are always stored in `./data/sessions`
+- `SESSION_PATH` - active sessions are stored in the database adapter; `./data/sessions` is only checked to delete old JSON session files
 - `LOG_LEVEL` - Logging is permanently configured
 - `ALLOWED_ORIGINS` - CORS is controlled via other mechanisms
 
@@ -290,7 +290,7 @@ spec:
               key: COOKIE_DOMAIN
         # Persistente Volume Mounts
         # Wichtig: Die Anwendung verwendet fest codierte Pfade relativ zum Arbeitsverzeichnis
-        # /app/data - für JSON-Dateien (rules.json, tracking.json, settings.json), Sessions (/app/data/sessions)
+        # /app/data - for SQLite (database.sqlite), migrated JSON backups, and uploads
         #           und standardmäßig auch Uploads (/app/data/uploads)
         # Nur ein Volume nötig, da Uploads standardmäßig in ./data/uploads gespeichert werden
         volumeMounts:
@@ -722,7 +722,7 @@ oc port-forward service/smartredirect-suite-service 8080:80
 
 ### Resource overview
 After successful deployment you will have the following resources:
-- **1 PersistentVolumeClaim** for data, sessions and uploads
+- **1 PersistentVolumeClaim** for database and uploads
 - **1 deployment** with 2 replicas (scalable)
 - **1 service** for internal communication
 - **1 route** for external HTTPS access

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
       },
       "engines": {
         "node": ">=20",
-        "npm": ">=11.6.4"
+        "npm": ">=10.9.0"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2cca705",
   "engines": {
     "node": ">=20",
-    "npm": ">=11.6.4"
+    "npm": ">=10.9.0"
   },
   "type": "module",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:../vite.config",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "test:unit": "tsx tests/shared/appMetadata.test.ts && tsx tests/shared/i18n.test.ts && tsx tests/client/url-utils.test.ts && tsx tests/shared/url-trace.test.ts",
-    "test": "npm run test:unit && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
+    "test": "npm run test:unit && tsx tests/integration/database-config.test.ts && tsx tests/integration/database-session-store.test.ts && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
     "check": "echo 'Skipping type check'"
   },
   "dependencies": {

--- a/server/databaseSessionStore.ts
+++ b/server/databaseSessionStore.ts
@@ -1,0 +1,187 @@
+import { Store, type SessionData } from 'express-session';
+import fs from 'fs/promises';
+import path from 'path';
+import { Op } from 'sequelize';
+import { initDb, AdminSessionModel } from './db';
+
+interface SessionStoreOptions {
+  cleanupIntervalMs?: number;
+  legacySessionsDir?: string;
+}
+
+function normalizeExpiry(value: unknown): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  const expiresAt = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(expiresAt.getTime()) ? null : expiresAt;
+}
+
+function getSessionExpiry(session: SessionData): Date | null {
+  return normalizeExpiry(session.cookie?.expires);
+}
+
+function isExpired(expiresAt: Date | null): boolean {
+  return Boolean(expiresAt && expiresAt.getTime() <= Date.now());
+}
+
+function isValidSessionId(sessionId: string): boolean {
+  return typeof sessionId === 'string' && sessionId.length > 0 && sessionId.length <= 255 && !/[\u0000-\u001f\u007f]/.test(sessionId);
+}
+
+export class DatabaseSessionStore extends Store {
+  private readonly cleanupIntervalMs: number;
+  private readonly legacySessionsDir: string;
+  private readonly readyPromise: Promise<void>;
+  private cleanupTimer: NodeJS.Timeout | null = null;
+
+  constructor(options: SessionStoreOptions = {}) {
+    super();
+    this.cleanupIntervalMs = options.cleanupIntervalMs ?? 60 * 60 * 1000;
+    this.legacySessionsDir = options.legacySessionsDir ?? path.join(process.cwd(), 'data', 'sessions');
+    this.readyPromise = this.initialize();
+  }
+
+  private async initialize(): Promise<void> {
+    await initDb();
+    await this.pruneExpiredSessions();
+    this.startCleanupTimer();
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.readyPromise;
+  }
+
+  private validateSessionId(sessionId: string): void {
+    if (!isValidSessionId(sessionId)) {
+      throw new Error('Invalid session ID');
+    }
+  }
+
+  override get(sessionId: string, callback: (err: any, session?: SessionData | null) => void): void {
+    (async () => {
+      this.validateSessionId(sessionId);
+      await this.ensureReady();
+
+      const row = await AdminSessionModel.findByPk(sessionId);
+      if (!row) {
+        callback(null, null);
+        return;
+      }
+
+      const expiresAt = normalizeExpiry(row.getDataValue('expiresAt'));
+      if (isExpired(expiresAt)) {
+        await row.destroy();
+        callback(null, null);
+        return;
+      }
+
+      callback(null, row.getDataValue('data') as SessionData);
+    })().catch(error => callback(error));
+  }
+
+  override set(sessionId: string, session: SessionData, callback?: (err?: any) => void): void {
+    (async () => {
+      this.validateSessionId(sessionId);
+      await this.ensureReady();
+
+      const expiresAt = getSessionExpiry(session);
+      await AdminSessionModel.upsert({
+        id: sessionId,
+        data: session,
+        expiresAt: expiresAt?.toISOString() ?? null,
+      } as any);
+
+      callback?.();
+    })().catch(error => callback?.(error));
+  }
+
+  override destroy(sessionId: string, callback?: (err?: any) => void): void {
+    (async () => {
+      this.validateSessionId(sessionId);
+      await this.ensureReady();
+      await AdminSessionModel.destroy({ where: { id: sessionId } });
+      callback?.();
+    })().catch(error => callback?.(error));
+  }
+
+  override touch(sessionId: string, session: SessionData, callback?: (err?: any) => void): void {
+    this.set(sessionId, session, callback);
+  }
+
+  override all(callback: (err: any, obj?: { [sid: string]: SessionData } | SessionData[] | null) => void): void {
+    (async () => {
+      await this.ensureReady();
+      await this.pruneExpiredSessions();
+      const rows = await AdminSessionModel.findAll();
+      callback(null, rows.map(row => row.getDataValue('data') as SessionData));
+    })().catch(error => callback(error));
+  }
+
+  override length(callback: (err: any, length?: number) => void): void {
+    (async () => {
+      await this.ensureReady();
+      await this.pruneExpiredSessions();
+      const count = await AdminSessionModel.count();
+      callback(null, count);
+    })().catch(error => callback(error));
+  }
+
+  override clear(callback?: (err?: any) => void): void {
+    (async () => {
+      await this.ensureReady();
+      await AdminSessionModel.destroy({ where: {} });
+      await this.clearLegacySessionFiles();
+      callback?.();
+    })().catch(error => callback?.(error));
+  }
+
+  async close(): Promise<void> {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
+  private startCleanupTimer(): void {
+    if (this.cleanupTimer || this.cleanupIntervalMs <= 0) {
+      return;
+    }
+
+    this.cleanupTimer = setInterval(() => {
+      this.pruneExpiredSessions().catch(error => {
+        console.warn('Session cleanup error:', error);
+      });
+    }, this.cleanupIntervalMs);
+    this.cleanupTimer.unref?.();
+  }
+
+  private async pruneExpiredSessions(): Promise<void> {
+    await AdminSessionModel.destroy({
+      where: {
+        expiresAt: {
+          [Op.lt]: new Date().toISOString(),
+        },
+      },
+    });
+  }
+
+  private async clearLegacySessionFiles(): Promise<void> {
+    let files: string[];
+    try {
+      files = await fs.readdir(this.legacySessionsDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+      return;
+    }
+
+    await Promise.all(
+      files
+        .filter(file => file.endsWith('.json'))
+        .map(file => fs.rm(path.join(this.legacySessionsDir, file), { force: true })),
+    );
+  }
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,38 +1,168 @@
-import { Sequelize, DataTypes, Model } from 'sequelize';
+import { Sequelize, DataTypes } from 'sequelize';
+import type { Dialect, Options } from 'sequelize';
 import path from 'path';
+import fs from 'fs/promises';
+import { z } from 'zod';
 
-const dialect = process.env.DB_DIALECT || 'sqlite';
-const storagePath = process.env.DB_STORAGE || path.join(process.cwd(), 'data', 'database.sqlite');
+const dialectAliases = {
+  postgresql: 'postgres',
+} as const;
 
-let sequelize: Sequelize;
+const supportedDialects = ['sqlite', 'postgres', 'mysql', 'mariadb'] as const;
+type SupportedDialect = (typeof supportedDialects)[number];
 
-if (dialect === 'sqlite') {
-  sequelize = new Sequelize({
-    dialect: 'sqlite',
-    storage: storagePath,
-    logging: false,
-  });
-} else {
-  sequelize = new Sequelize(
-    process.env.DB_NAME || 'smartredirect',
-    process.env.DB_USER || 'root',
-    process.env.DB_PASSWORD || '',
-    {
-      host: process.env.DB_HOST || 'localhost',
-      port: parseInt(process.env.DB_PORT || (dialect === 'postgres' ? '5432' : '3306'), 10),
-      dialect: dialect as any,
-      logging: false,
-    }
-  );
+const databaseEnvSchema = z.object({
+  DB_DIALECT: z.string().optional().default('sqlite'),
+  DB_STORAGE: z.string().optional(),
+  DB_NAME: z.string().optional().default('smartredirect'),
+  DB_USER: z.string().optional().default('root'),
+  DB_PASSWORD: z.string().optional().default(''),
+  DB_HOST: z.string().optional().default('localhost'),
+  DB_PORT: z.string().optional(),
+  DB_SSL: z.string().optional().default('false'),
+  DB_POOL_MAX: z.string().optional().default('5'),
+  DB_POOL_MIN: z.string().optional().default('0'),
+  DB_POOL_ACQUIRE_MS: z.string().optional().default('30000'),
+  DB_POOL_IDLE_MS: z.string().optional().default('10000'),
+});
+
+export interface DatabaseConfig {
+  dialect: SupportedDialect;
+  storagePath: string;
+  database: string;
+  username: string;
+  password: string;
+  host: string;
+  port: number;
+  ssl: boolean;
+  pool: {
+    max: number;
+    min: number;
+    acquire: number;
+    idle: number;
+  };
 }
 
-// Models
+function parsePositiveInteger(value: string, fallback: number, name: string): number {
+  const parsedValue = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsedValue) || parsedValue < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+
+  return parsedValue || fallback;
+}
+
+export function normalizeDatabaseDialect(rawDialect: string | undefined): SupportedDialect {
+  const normalizedDialect = (rawDialect || 'sqlite').trim().toLowerCase();
+  const aliasedDialect = dialectAliases[normalizedDialect as keyof typeof dialectAliases] ?? normalizedDialect;
+
+  if (!supportedDialects.includes(aliasedDialect as SupportedDialect)) {
+    throw new Error(
+      `Unsupported DB_DIALECT "${rawDialect}". Supported values: sqlite, postgres/postgresql, mysql, mariadb.`,
+    );
+  }
+
+  return aliasedDialect as SupportedDialect;
+}
+
+export function loadDatabaseConfig(env: NodeJS.ProcessEnv = process.env): DatabaseConfig {
+  const parsedEnvironment = databaseEnvSchema.parse(env);
+  const dialect = normalizeDatabaseDialect(parsedEnvironment.DB_DIALECT);
+  const defaultPort = dialect === 'postgres' ? 5432 : 3306;
+
+  return {
+    dialect,
+    storagePath: parsedEnvironment.DB_STORAGE || path.join(process.cwd(), 'data', 'database.sqlite'),
+    database: parsedEnvironment.DB_NAME,
+    username: parsedEnvironment.DB_USER,
+    password: parsedEnvironment.DB_PASSWORD,
+    host: parsedEnvironment.DB_HOST,
+    port: dialect === 'sqlite' ? 0 : parsePositiveInteger(parsedEnvironment.DB_PORT || String(defaultPort), defaultPort, 'DB_PORT'),
+    ssl: parsedEnvironment.DB_SSL.toLowerCase() === 'true',
+    pool: {
+      max: parsePositiveInteger(parsedEnvironment.DB_POOL_MAX, 5, 'DB_POOL_MAX'),
+      min: parsePositiveInteger(parsedEnvironment.DB_POOL_MIN, 0, 'DB_POOL_MIN'),
+      acquire: parsePositiveInteger(parsedEnvironment.DB_POOL_ACQUIRE_MS, 30000, 'DB_POOL_ACQUIRE_MS'),
+      idle: parsePositiveInteger(parsedEnvironment.DB_POOL_IDLE_MS, 10000, 'DB_POOL_IDLE_MS'),
+    },
+  };
+}
+
+function createSequelizeOptions(config: DatabaseConfig): Options {
+  const commonOptions: Options = {
+    dialect: config.dialect as Dialect,
+    logging: false,
+    pool: config.dialect === 'sqlite' ? undefined : config.pool,
+  };
+
+  if (config.dialect === 'sqlite') {
+    return {
+      ...commonOptions,
+      storage: config.storagePath,
+    };
+  }
+
+  return {
+    ...commonOptions,
+    host: config.host,
+    port: config.port,
+    dialectOptions: config.ssl
+      ? {
+          ssl: {
+            require: true,
+            rejectUnauthorized: false,
+          },
+        }
+      : undefined,
+  };
+}
+
+export function createSequelize(config: DatabaseConfig = loadDatabaseConfig()): Sequelize {
+  if (config.dialect === 'sqlite') {
+    return new Sequelize(createSequelizeOptions(config));
+  }
+
+  return new Sequelize(config.database, config.username, config.password, createSequelizeOptions(config));
+}
+
+export function parseJsonField<T>(value: unknown, fallback: T): T {
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
+
+  if (typeof value !== 'string') {
+    return value as T;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function serializeJsonField(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return JSON.stringify(value);
+}
+
+const databaseConfig = loadDatabaseConfig();
+const sequelize = createSequelize(databaseConfig);
+const modelOptions = {};
+
 export const UrlRuleModel = sequelize.define('UrlRule', {
   id: {
     type: DataTypes.TEXT,
     primaryKey: true,
   },
-  matcher: DataTypes.TEXT,
+  matcher: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
   targetUrl: DataTypes.TEXT,
   redirectType: DataTypes.TEXT,
   infoText: DataTypes.TEXT,
@@ -42,34 +172,37 @@ export const UrlRuleModel = sequelize.define('UrlRule', {
   keptQueryParams: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('keptQueryParams');
-      return val ? JSON.parse(val) : [];
+      return parseJsonField(this.getDataValue('keptQueryParams'), []);
     },
-    set(val) {
-      this.setDataValue('keptQueryParams', JSON.stringify(val));
-    }
+    set(value) {
+      this.setDataValue('keptQueryParams', serializeJsonField(value));
+    },
   },
   forwardQueryParams: DataTypes.BOOLEAN,
   searchAndReplace: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('searchAndReplace');
-      return val ? JSON.parse(val) : [];
+      return parseJsonField(this.getDataValue('searchAndReplace'), []);
     },
-    set(val) {
-      this.setDataValue('searchAndReplace', JSON.stringify(val));
-    }
+    set(value) {
+      this.setDataValue('searchAndReplace', serializeJsonField(value));
+    },
   },
   staticQueryParams: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('staticQueryParams');
-      return val ? JSON.parse(val) : [];
+      return parseJsonField(this.getDataValue('staticQueryParams'), []);
     },
-    set(val) {
-      this.setDataValue('staticQueryParams', JSON.stringify(val));
-    }
-  }
+    set(value) {
+      this.setDataValue('staticQueryParams', serializeJsonField(value));
+    },
+  },
+}, {
+  ...modelOptions,
+  indexes: [
+    { fields: ['matcher'] },
+    { fields: ['createdAt'] },
+  ],
 });
 
 export const UrlTrackingModel = sequelize.define('UrlTracking', {
@@ -85,22 +218,20 @@ export const UrlTrackingModel = sequelize.define('UrlTracking', {
   ruleIds: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('ruleIds');
-      return val ? JSON.parse(val) : [];
+      return parseJsonField(this.getDataValue('ruleIds'), []);
     },
-    set(val) {
-      this.setDataValue('ruleIds', val ? JSON.stringify(val) : null);
-    }
+    set(value) {
+      this.setDataValue('ruleIds', serializeJsonField(value));
+    },
   },
   matchedRuleInfo: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('matchedRuleInfo');
-      return val ? JSON.parse(val) : undefined;
+      return parseJsonField(this.getDataValue('matchedRuleInfo'), undefined);
     },
-    set(val) {
-      this.setDataValue('matchedRuleInfo', val ? JSON.stringify(val) : null);
-    }
+    set(value) {
+      this.setDataValue('matchedRuleInfo', serializeJsonField(value));
+    },
   },
   userAgent: DataTypes.TEXT,
   referrer: DataTypes.TEXT,
@@ -112,13 +243,47 @@ export const UrlTrackingModel = sequelize.define('UrlTracking', {
   searchQueryInfo: {
     type: DataTypes.TEXT,
     get() {
-      const val = this.getDataValue('searchQueryInfo');
-      return val ? JSON.parse(val) : undefined;
+      return parseJsonField(this.getDataValue('searchQueryInfo'), undefined);
     },
-    set(val) {
-      this.setDataValue('searchQueryInfo', val ? JSON.stringify(val) : null);
-    }
-  }
+    set(value) {
+      this.setDataValue('searchQueryInfo', serializeJsonField(value));
+    },
+  },
+}, {
+  ...modelOptions,
+  indexes: [
+    { fields: ['timestamp'] },
+    { fields: ['path'] },
+    { fields: ['ruleId'] },
+    { fields: ['feedback'] },
+    { fields: ['matchQuality'] },
+  ],
+});
+
+export const AdminSessionModel = sequelize.define('AdminSession', {
+  id: {
+    type: DataTypes.TEXT,
+    primaryKey: true,
+  },
+  data: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    get() {
+      return parseJsonField(this.getDataValue('data'), {});
+    },
+    set(value) {
+      this.setDataValue('data', JSON.stringify(value ?? {}));
+    },
+  },
+  expiresAt: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  },
+}, {
+  ...modelOptions,
+  indexes: [
+    { fields: ['expiresAt'] },
+  ],
 });
 
 export const GeneralSettingsModel = sequelize.define('GeneralSettings', {
@@ -126,20 +291,43 @@ export const GeneralSettingsModel = sequelize.define('GeneralSettings', {
     type: DataTypes.TEXT,
     primaryKey: true,
   },
-  // just store everything as a single JSON text field for simplicity,
-  // since settings is a single object
   data: {
     type: DataTypes.TEXT,
+    allowNull: false,
     get() {
-      const val = this.getDataValue('data');
-      return val ? JSON.parse(val) : {};
+      return parseJsonField(this.getDataValue('data'), {});
     },
-    set(val) {
-      this.setDataValue('data', JSON.stringify(val));
-    }
-  }
-});
+    set(value) {
+      this.setDataValue('data', JSON.stringify(value ?? {}));
+    },
+  },
+}, modelOptions);
 
+export const GeneralSettingEntryModel = sequelize.define('GeneralSettingEntry', {
+  key: {
+    type: DataTypes.TEXT,
+    primaryKey: true,
+  },
+  category: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+  value: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    get() {
+      return parseJsonField(this.getDataValue('value'), null);
+    },
+    set(value) {
+      this.setDataValue('value', JSON.stringify(value));
+    },
+  },
+}, {
+  ...modelOptions,
+  indexes: [
+    { fields: ['category'] },
+  ],
+});
 
 export const TranslationModel = sequelize.define('Translation', {
   lang: {
@@ -148,18 +336,31 @@ export const TranslationModel = sequelize.define('Translation', {
   },
   data: {
     type: DataTypes.TEXT,
+    allowNull: false,
     get() {
-      const val = this.getDataValue('data');
-      return val ? JSON.parse(val) : {};
+      return parseJsonField(this.getDataValue('data'), {});
     },
-    set(val) {
-      this.setDataValue('data', JSON.stringify(val));
-    }
-  }
-});
+    set(value) {
+      this.setDataValue('data', JSON.stringify(value ?? {}));
+    },
+  },
+}, modelOptions);
+
+let initDbPromise: Promise<void> | null = null;
 
 export async function initDb() {
-  await sequelize.sync();
+  if (!initDbPromise) {
+    initDbPromise = (async () => {
+      if (databaseConfig.dialect === 'sqlite') {
+        await fs.mkdir(path.dirname(databaseConfig.storagePath), { recursive: true });
+      }
+
+      await sequelize.authenticate();
+      await sequelize.sync();
+    })();
+  }
+
+  return initDbPromise;
 }
 
-export { sequelize };
+export { sequelize, databaseConfig };

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,7 @@ import helmet from "helmet";
 import { randomBytes } from "crypto";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
-import { FileSessionStore } from "./fileSessionStore";
+import { DatabaseSessionStore } from "./databaseSessionStore";
 import { rateLimitMiddleware, adminRateLimitMiddleware, csrfCheck } from "./middleware/security";
 
 const app = express();
@@ -122,9 +122,9 @@ app.use((req, res, next) => {
 });
 
 // Session configuration
-const sessionStore = new FileSessionStore();
+const sessionStore = new DatabaseSessionStore();
 sessionStore.clear(() => {
-  console.log("INFO: Alle existierenden Sitzungen wurden bereinigt.");
+  console.log("INFO: Database-backed admin sessions were cleared on startup.");
 });
 
 const sessionMiddleware = session({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import express, { type Express } from "express";
 import { createServer, type Server } from "http";
 import { createHash, timingSafeEqual } from "crypto";
 import { storage } from "./storage";
+import { initDb, AdminSessionModel } from "./db";
 import {
   insertUrlTrackingSchema,
   exportRequestSchema,
@@ -64,40 +65,40 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const startTime = Date.now();
       const uptime = process.uptime();
       const memoryUsage = process.memoryUsage();
-      
+
       // Check filesystem by verifying data directory exists
       const fs = await import('fs/promises');
       const path = await import('path');
       const dataDir = path.join(process.cwd(), 'data');
-      
+
       let filesystemCheck = { status: "error", responseTime: 0, error: "" };
       const fsStart = Date.now();
       try {
         await fs.access(dataDir);
         filesystemCheck = { status: "ok" as const, responseTime: Date.now() - fsStart, error: "" };
       } catch (error) {
-        filesystemCheck = { 
-          status: "error" as const, 
-          responseTime: Date.now() - fsStart, 
-          error: error instanceof Error ? error.message : "Unknown error" 
+        filesystemCheck = {
+          status: "error" as const,
+          responseTime: Date.now() - fsStart,
+          error: error instanceof Error ? error.message : "Unknown error"
         };
       }
-      
-      // Check sessions by verifying session directory
+
+      // Check database-backed sessions by querying the AdminSessions table.
       let sessionsCheck = { status: "error", responseTime: 0, error: "" };
       const sessionsStart = Date.now();
       try {
-        const sessionsDir = path.join(dataDir, 'sessions');
-        await fs.access(sessionsDir);
+        await initDb();
+        await AdminSessionModel.count();
         sessionsCheck = { status: "ok" as const, responseTime: Date.now() - sessionsStart, error: "" };
       } catch (error) {
-        sessionsCheck = { 
-          status: "error" as const, 
-          responseTime: Date.now() - sessionsStart, 
-          error: error instanceof Error ? error.message : "Sessions directory not accessible" 
+        sessionsCheck = {
+          status: "error" as const,
+          responseTime: Date.now() - sessionsStart,
+          error: error instanceof Error ? error.message : "Session database not accessible"
         };
       }
-      
+
       // Check storage by attempting to read settings
       let storageCheck = { status: "error", responseTime: 0, error: "" };
       const storageStart = Date.now();
@@ -105,17 +106,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
         await storage.getGeneralSettings();
         storageCheck = { status: "ok" as const, responseTime: Date.now() - storageStart, error: "" };
       } catch (error) {
-        storageCheck = { 
-          status: "error" as const, 
-          responseTime: Date.now() - storageStart, 
-          error: error instanceof Error ? error.message : "Storage error" 
+        storageCheck = {
+          status: "error" as const,
+          responseTime: Date.now() - storageStart,
+          error: error instanceof Error ? error.message : "Storage error"
         };
       }
-      
-      const overallStatus = (filesystemCheck.status === "ok" && 
-                            sessionsCheck.status === "ok" && 
+
+      const overallStatus = (filesystemCheck.status === "ok" &&
+                            sessionsCheck.status === "ok" &&
                             storageCheck.status === "ok") ? "healthy" : "unhealthy";
-      
+
       const healthResponse = {
         status: overallStatus,
         timestamp: new Date().toISOString(),
@@ -128,7 +129,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         },
         responseTime: Date.now() - startTime
       };
-      
+
       // Return 200 for healthy, 503 for unhealthy
       const statusCode = overallStatus === "healthy" ? 200 : 503;
       res.status(statusCode).json(healthResponse);
@@ -141,7 +142,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       });
     }
   });
-  
+
     // Serve sample import file (Dynamic)
   const SAMPLE_RULES = [{
     id: "sample-id",
@@ -177,7 +178,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     res.setHeader('Content-Disposition', 'attachment; filename="sample-rules-import.xlsx"');
     res.send(buffer);
   });
-  
+
   // URL-Tracking endpoint
   app.post("/api/track", trackingRateLimiter, async (req, res) => {
     try {
@@ -461,9 +462,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.get("/api/admin/status", (req, res) => {
-    res.json({ 
+    res.json({
       isAuthenticated: !!req.session?.isAdminAuthenticated,
-      loginTime: req.session?.adminLoginTime 
+      loginTime: req.session?.adminLoginTime
     });
   });
 
@@ -512,7 +513,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const sortBy = req.query.sortBy as string || 'createdAt';
       const sortOrder = (req.query.sortOrder as 'asc' | 'desc') || 'desc';
-      
+
       // If search is provided but empty or whitespace only, treat it as undefined
       const cleanSearch = (search && typeof search === 'string' && search.trim().length > 0) ? search.trim() : undefined;
 
@@ -548,7 +549,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (error instanceof Error) {
         // Extract clean error message from Zod validation errors
         let cleanMessage = error.message;
-        
+
         // Handle Zod validation errors specifically
         if (error.message.includes('[') && error.message.includes('"message"')) {
           try {
@@ -561,8 +562,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
             cleanMessage = "Ungültige Eingabedaten. Bitte überprüfen Sie Ihre Eingaben.";
           }
         }
-        
-        res.status(400).json({ 
+
+        res.status(400).json({
           error: cleanMessage
         });
       } else {
@@ -575,7 +576,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const { id } = req.params;
       const { forceUpdate, ...updateData } = req.body as Partial<InsertUrlRule>;
-      
+
       // If forceUpdate is true, skip validation and update directly
       if (forceUpdate) {
         const rule = await storage.updateUrlRule(id, updateData, true); // Pass force flag
@@ -603,7 +604,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (error instanceof Error) {
         // Extract clean error message from Zod validation errors
         let cleanMessage = error.message;
-        
+
         // Handle Zod validation errors specifically
         if (error.message.includes('[') && error.message.includes('"message"')) {
           try {
@@ -616,8 +617,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
             cleanMessage = "Ungültige Eingabedaten. Bitte überprüfen Sie Ihre Eingaben.";
           }
         }
-        
-        res.status(400).json({ 
+
+        res.status(400).json({
           error: cleanMessage
         });
       } else {
@@ -797,7 +798,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const timeRange = req.query.timeRange as '24h' | '7d' | 'all' | undefined;
       const stats = await storage.getTrackingStats();
       const topUrls = await storage.getTopUrls(10, timeRange);
-      
+
       res.json({
         stats,
         topUrls,
@@ -813,7 +814,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const timeRange = req.query.timeRange as '24h' | '7d' | 'all' | undefined;
       const topUrls = await storage.getTopUrls(100, timeRange);
-      
+
       res.json(topUrls);
     } catch (error) {
       console.error("Top 100 stats error:", error);
@@ -856,10 +857,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const entries = await storage.searchTrackingEntries(
         cleanQuery,
-        sortBy as string, 
+        sortBy as string,
         sortOrder as 'asc' | 'desc'
       );
-      
+
       res.json(entries);
     } catch (error) {
       console.error("Tracking entries error:", error);
@@ -880,7 +881,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const sortBy = req.query.sortBy as string || 'timestamp';
       const sortOrder = req.query.sortOrder as 'asc' | 'desc' || 'desc';
-      
+
       // Backward compatibility handling:
       // If ruleFilter is provided, use it.
       // If not, check excludeNoRule: true -> 'with_rule', false -> 'all'
@@ -948,10 +949,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const exportRequest = exportRequestSchema.parse(req.body);
       const settings = await storage.getGeneralSettings();
-      
+
       if (exportRequest.type === 'statistics') {
         const trackingData = await storage.getTrackingData(exportRequest.timeRange);
-        
+
         if (exportRequest.format === 'csv') {
           const includeReferrer = settings.enableReferrerTracking;
           // CSV-Export
@@ -971,7 +972,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
               return `"${track.id}","${track.oldUrl}","${(track as any).newUrl || ''}","${track.path}","${track.timestamp}","${track.userAgent || ''}","${ruleId}","${feedback}","${quality}","${userProposedUrl}"`;
             }
           }).join('\n');
-          
+
           res.setHeader('Content-Type', 'text/csv');
           res.setHeader('Content-Disposition', 'attachment; filename="statistics.csv"');
           res.send(csvHeader + csvData);
@@ -1042,7 +1043,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const importRequest = importSettingsRequestSchema.parse(req.body);
       const updatedSettings = await storage.updateGeneralSettings(importRequest.settings);
-      
+
       res.json({
         success: true,
         settings: updatedSettings
@@ -1101,7 +1102,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.setHeader('Content-Disposition', 'attachment; filename="settings.json"');
       res.send(JSON.stringify(settings, null, 2));
     } catch (error) {
-      console.error("Settings export error:", error);  
+      console.error("Settings export error:", error);
       res.status(500).json({ error: "Settings Export fehlgeschlagen" });
     }
   });
@@ -1137,15 +1138,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json(settings);
     } catch (error) {
       console.error("Update settings error:", error);
-      
+
       // If it's a Zod validation error, return the specific validation messages
       if (error instanceof z.ZodError) {
         const zodValidationErrors = (error.errors || []).map(err => ({
           field: err.path.join('.'),
           message: err.message
         }));
-        
-        res.status(400).json({ 
+
+        res.status(400).json({
           error: "Validierungsfehler",
           validationErrors: zodValidationErrors,
           details: zodValidationErrors.map(e => `${e.field}: ${e.message}`).join(', ')
@@ -1159,7 +1160,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Local File Upload Route for Logo
   const localUploadService = new LocalFileUploadService();
   const upload = localUploadService.getMulterConfig();
-  
+
   // Custom upload config for imports (JSON, CSV, Excel)
   const uploadDir = process.env.LOCAL_UPLOAD_PATH || './data/uploads';
 
@@ -1283,7 +1284,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (logoUrl.startsWith('/uploads/')) {
         const filename = logoUrl.replace('/uploads/', '');
         console.log(`Attempting to delete logo file: ${filename} from URL: ${logoUrl}`);
-        
+
         // Try to delete the file - success or failure doesn't matter for the API response
         // as the important thing is removing the logo URL from settings
         const fileDeleted = localUploadService.deleteFile(filename);
@@ -1296,7 +1297,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const updatedSettings = await storage.updateGeneralSettings({
         headerLogoUrl: null
       } as any);
-      
+
       console.log("Logo deletion - settings updated, headerLogoUrl removed:", !updatedSettings.headerLogoUrl);
 
       res.json({
@@ -1314,7 +1315,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     const filename = req.params.filename;
     const uploadPath = process.env.LOCAL_UPLOAD_PATH || './data/uploads';
     const filePath = path.join(uploadPath, filename);
-    
+
     if (localUploadService.fileExists(filename)) {
       res.sendFile(path.resolve(filePath));
     } else {

--- a/tests/integration/database-config.test.ts
+++ b/tests/integration/database-config.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+
+process.env.DB_DIALECT = "sqlite";
+const { normalizeDatabaseDialect, loadDatabaseConfig, sequelize } = await import("../../server/db");
+
+console.log("Running database configuration tests...");
+
+assert.equal(normalizeDatabaseDialect("postgresql"), "postgres");
+assert.equal(normalizeDatabaseDialect("mariadb"), "mariadb");
+assert.throws(
+  () => normalizeDatabaseDialect("oracle"),
+  /Unsupported DB_DIALECT/,
+  "Unsupported dialects must fail during configuration validation",
+);
+
+const postgresConfig = loadDatabaseConfig({
+  DB_DIALECT: "postgresql",
+  DB_NAME: "smartredirect",
+  DB_USER: "redirectuser",
+  DB_PASSWORD: "redirectpass",
+  DB_HOST: "db",
+  DB_SSL: "true",
+});
+
+assert.equal(postgresConfig.dialect, "postgres");
+assert.equal(postgresConfig.port, 5432);
+assert.equal(postgresConfig.ssl, true);
+
+const mariadbConfig = loadDatabaseConfig({
+  DB_DIALECT: "mariadb",
+  DB_NAME: "smartredirect",
+  DB_USER: "redirectuser",
+  DB_PASSWORD: "redirectpass",
+  DB_HOST: "db",
+});
+
+assert.equal(mariadbConfig.dialect, "mariadb");
+assert.equal(mariadbConfig.port, 3306);
+
+await sequelize.close();
+console.log("database configuration tests passed");

--- a/tests/integration/database-session-store.test.ts
+++ b/tests/integration/database-session-store.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { SessionData } from "express-session";
+
+const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "srs-session-store-"));
+process.chdir(tempDirectory);
+process.env.DB_DIALECT = "sqlite";
+process.env.DB_STORAGE = path.join(tempDirectory, "data", "sessions.sqlite");
+
+const { DatabaseSessionStore } = await import("../../server/databaseSessionStore");
+const { AdminSessionModel, sequelize } = await import("../../server/db");
+
+type StoreInstance = InstanceType<typeof DatabaseSessionStore>;
+
+function setSession(store: StoreInstance, sessionId: string, session: Partial<SessionData>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    store.set(sessionId, session as SessionData, error => (error ? reject(error) : resolve()));
+  });
+}
+
+function getSession(store: StoreInstance, sessionId: string): Promise<SessionData | null | undefined> {
+  return new Promise((resolve, reject) => {
+    store.get(sessionId, (error, session) => (error ? reject(error) : resolve(session)));
+  });
+}
+
+function getLength(store: StoreInstance): Promise<number> {
+  return new Promise((resolve, reject) => {
+    store.length((error, length) => (error ? reject(error) : resolve(length ?? 0)));
+  });
+}
+
+async function runDatabaseSessionStoreTests() {
+  console.log("Running database session store tests...");
+  const legacyDirectory = path.join(tempDirectory, "data", "sessions");
+  await fs.mkdir(legacyDirectory, { recursive: true });
+
+  const store = new DatabaseSessionStore({ legacySessionsDir: legacyDirectory, cleanupIntervalMs: 0 });
+  const expires = new Date(Date.now() + 60_000);
+
+  await setSession(store, "admin-session-1", {
+    cookie: { expires } as SessionData["cookie"],
+    isAdminAuthenticated: true,
+    adminLoginTime: 123,
+  });
+
+  const persistedRow = await AdminSessionModel.findByPk("admin-session-1");
+  assert.ok(persistedRow, "session must be persisted in the database");
+  assert.equal(persistedRow?.getDataValue("expiresAt"), expires.toISOString());
+
+  const restoredSession = await getSession(store, "admin-session-1");
+  assert.equal(restoredSession?.isAdminAuthenticated, true);
+  assert.equal(restoredSession?.adminLoginTime, 123);
+  assert.equal(await getLength(store), 1);
+
+  await setSession(store, "expired-session", {
+    cookie: { expires: new Date(Date.now() - 60_000) } as SessionData["cookie"],
+    isAdminAuthenticated: true,
+  });
+  assert.equal(await getSession(store, "expired-session"), null, "expired sessions must be removed on read");
+  assert.equal(await AdminSessionModel.findByPk("expired-session"), null);
+
+  await fs.writeFile(path.join(legacyDirectory, "legacy-session.json"), JSON.stringify({ data: {}, expires: expires.toISOString() }));
+  await setSession(store, "session-cleared-on-startup", {
+    cookie: { expires } as SessionData["cookie"],
+    isAdminAuthenticated: true,
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    store.clear(error => (error ? reject(error) : resolve()));
+  });
+
+  assert.equal(await getLength(store), 0, "startup cleanup must remove DB-backed sessions");
+  await assert.rejects(
+    () => fs.access(path.join(legacyDirectory, "legacy-session.json")),
+    /ENOENT/,
+    "startup cleanup must delete legacy JSON sessions instead of importing them",
+  );
+
+  await store.close();
+  await sequelize.close();
+  console.log("database session store tests passed");
+}
+
+runDatabaseSessionStoreTests().catch(async error => {
+  console.error(error);
+  await sequelize.close().catch(() => undefined);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Reconcile the i18n/translation work with the NextRelease changes that introduced database-backed storage and session handling so both features work together smoothly. 
- Replace fragile file-based admin sessions with a database-backed store to improve reliability, cleanup and compatibility with multi-node deployments. 
- Keep runtime documentation, CI and deployment guides consistent with the new database-backed storage approach and surface required environment variables. 
- Add integration tests to prevent regressions around DB config parsing and admin session persistence/cleanup.

### Description
- Implemented a typed DB configuration layer in `server/db.ts` with `normalizeDatabaseDialect`, `loadDatabaseConfig`, `createSequelize`, JSON field helpers and models for `UrlRule`, `UrlTracking`, `AdminSession`, `GeneralSettings`, `GeneralSettingEntry` and `Translation`.  
- Added a `DatabaseSessionStore` (`server/databaseSessionStore.ts`) and switched Express to use it in `server/index.ts`, including expiry pruning and deletion of legacy JSON session files.  
- Updated API and health check behavior in `server/routes.ts` to validate the database-backed session store via `initDb()` and `AdminSessionModel`.  
- Documentation and config updates: updated `.env.example`, `README.md`, `docs/*` (Docker/OpenShift/Enterprise/Installation/API/Architecture) to reflect SQLite-by-default DB, `DB_*` env vars, session semantics and CI audit step.  
- CI and package metadata changes: added `npm audit --audit-level=low` to the pipeline, bumped the semantic-release action version, relaxed `npm` engine floor to `>=10.9.0`, and updated `package.json` test scripts to include the new DB integration tests.  
- Tests: added integration tests `tests/integration/database-config.test.ts` and `tests/integration/database-session-store.test.ts` which exercise dialect normalization, config parsing and DB-backed session behavior.  

### Testing
- Ran `npm run test:unit` successfully where `tests/shared/*` and client helper tests passed. 
- Ran `git diff --check` and static diffs; no merge conflict markers remain and trailing whitespace fixes applied. 
- Attempted full `npm test` and `npm run build` in this environment but they could not complete due to the local `node_modules` state: the test runner failed with a missing `sequelize` entrypoint and the build failed due to a missing Vite runtime dependency (`fdir`), so integration and build steps could not be fully executed here. 
- `npm audit --audit-level=low` in CI is added; in this environment the audit run returned `403 Forbidden` via the proxy so the audit could not complete locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060542295483318daa1597f4732668)