### PR TITLE
fix: handle sqlite schema sync statements

### DIFF
--- a/server/betterSqlite3Dialect.ts
+++ b/server/betterSqlite3Dialect.ts
@@ -1,6 +1,7 @@
 import { createRequire } from 'module';
 
 interface BetterSqliteStatement {
+  readonly reader?: boolean;
   all(...parameters: unknown[]): unknown[];
   get(...parameters: unknown[]): unknown;
   run(...parameters: unknown[]): { lastInsertRowid?: number | bigint; changes?: number };
@@ -57,6 +58,14 @@ function invokeCallback(callback: SqliteCallback | undefined, error: Error | nul
   deferCallback(() => callback(error, rows));
 }
 
+function isNonReturningStatementError(error: unknown): boolean {
+  return error instanceof TypeError && error.message.includes('This statement does not return data');
+}
+
+function runNonReturningStatement(statement: BetterSqliteStatement, parameters: unknown[]): void {
+  statement.run(...parameters);
+}
+
 export class BetterSqlite3SequelizeDatabase {
   readonly filename: string;
   readonly uuid?: string;
@@ -109,10 +118,29 @@ export class BetterSqlite3SequelizeDatabase {
     const callback = extractCallback<SqliteCallback>(parameters, undefined);
 
     try {
-      const row = this.database.prepare(sql).get(...normalizeParameters(parameters[0]));
+      const normalizedParameters = normalizeParameters(parameters[0]);
+      const statement = this.database.prepare(sql);
+      if (statement.reader === false) {
+        runNonReturningStatement(statement, normalizedParameters);
+        invokeCallback(callback, null);
+        return this;
+      }
+
+      const row = statement.get(...normalizedParameters);
       invokeCallback(callback, null, row);
     } catch (error) {
-      if (callback) {
+      if (isNonReturningStatementError(error)) {
+        try {
+          runNonReturningStatement(this.database.prepare(sql), normalizeParameters(parameters[0]));
+          invokeCallback(callback, null);
+        } catch (runError) {
+          if (callback) {
+            invokeCallback(callback, runError as Error);
+          } else {
+            throw runError;
+          }
+        }
+      } else if (callback) {
         invokeCallback(callback, error as Error);
       } else {
         throw error;
@@ -126,10 +154,29 @@ export class BetterSqlite3SequelizeDatabase {
     const callback = extractCallback<SqliteCallback>(parameters, undefined);
 
     try {
-      const rows = this.database.prepare(sql).all(...normalizeParameters(parameters[0]));
+      const normalizedParameters = normalizeParameters(parameters[0]);
+      const statement = this.database.prepare(sql);
+      if (statement.reader === false) {
+        runNonReturningStatement(statement, normalizedParameters);
+        invokeCallback(callback, null, []);
+        return this;
+      }
+
+      const rows = statement.all(...normalizedParameters);
       invokeCallback(callback, null, rows);
     } catch (error) {
-      if (callback) {
+      if (isNonReturningStatementError(error)) {
+        try {
+          runNonReturningStatement(this.database.prepare(sql), normalizeParameters(parameters[0]));
+          invokeCallback(callback, null, []);
+        } catch (runError) {
+          if (callback) {
+            invokeCallback(callback, runError as Error);
+          } else {
+            throw runError;
+          }
+        }
+      } else if (callback) {
         invokeCallback(callback, error as Error);
       } else {
         throw error;

--- a/tests/integration/better-sqlite3-dialect.test.ts
+++ b/tests/integration/better-sqlite3-dialect.test.ts
@@ -6,7 +6,11 @@ const originalLoad = loadModule._load;
 const openedDatabases: FakeBetterSqliteDatabase[] = [];
 
 class FakeBetterSqliteStatement {
-  constructor(private readonly database: FakeBetterSqliteDatabase, private readonly sql: string) {}
+  readonly reader: boolean;
+
+  constructor(private readonly database: FakeBetterSqliteDatabase, private readonly sql: string) {
+    this.reader = /^\s*(?:SELECT|PRAGMA)\b/i.test(sql);
+  }
 
   run(...parameters: unknown[]) {
     this.database.operations.push({ method: "run", sql: this.sql, parameters });
@@ -14,11 +18,19 @@ class FakeBetterSqliteStatement {
   }
 
   get(...parameters: unknown[]) {
+    if (!this.reader) {
+      throw new TypeError("This statement does not return data. Use run() instead");
+    }
+
     this.database.operations.push({ method: "get", sql: this.sql, parameters });
     return { id: 1, name: "single-row" };
   }
 
   all(...parameters: unknown[]) {
+    if (!this.reader) {
+      throw new TypeError("This statement does not return data. Use run() instead");
+    }
+
     this.database.operations.push({ method: "all", sql: this.sql, parameters });
     return [{ id: 1 }, { id: 2 }];
   }
@@ -105,9 +117,22 @@ async function runBetterSqlite3DialectTests() {
     });
 
     assert.deepEqual(selectedRows, [{ id: 1 }, { id: 2 }]);
-    assert.deepEqual(openedDatabases[0].operations.slice(0, 2), [
+
+    const createTableRows = await new Promise<unknown>((resolve, reject) => {
+      database.all("CREATE TABLE IF NOT EXISTS redirects(id TEXT PRIMARY KEY)", [], (error, rows) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(rows);
+      });
+    });
+
+    assert.deepEqual(createTableRows, []);
+    assert.deepEqual(openedDatabases[0].operations.slice(0, 3), [
       { method: "run", sql: "INSERT INTO redirects(target) VALUES (?)", parameters: ["https://example.com"] },
       { method: "all", sql: "SELECT * FROM redirects WHERE target = ?", parameters: ["https://example.com"] },
+      { method: "run", sql: "CREATE TABLE IF NOT EXISTS redirects(id TEXT PRIMARY KEY)", parameters: [] },
     ]);
 
     let serializeCalled = false;


### PR DESCRIPTION
### Motivation
- Sequelize's sqlite sync path can call `get`/`all` for DDL statements which `better-sqlite3` treats as non-returning, causing schema initialization (e.g. `CREATE TABLE IF NOT EXISTS`) to fail with `TypeError: This statement does not return data. Use run() instead`.

### Description
- Route non-returning `better-sqlite3` statements invoked via Sequelize's `get`/`all` paths to `run()` by detecting `statement.reader === false` and executing the statement with `run()` instead of `get`/`all` in `server/betterSqlite3Dialect.ts`.
- Add a fallback that matches the sqlite-style TypeError message and retries the statement via `run()` when the environment surfaces the error instead of exposing `reader`.
- Add `isNonReturningStatementError` and `runNonReturningStatement` helpers and update callback behavior to preserve Sequelize-style async callbacks.
- Extend the integration test fake in `tests/integration/better-sqlite3-dialect.test.ts` to emulate `reader`/non-reader statements and to assert that calling `database.all` for a DDL returns an empty array and that the underlying operation used `run()`.
- Files changed: `server/betterSqlite3Dialect.ts`, `tests/integration/better-sqlite3-dialect.test.ts`.

### Testing
- Ran the targeted integration test with the local runner using `node node_modules/tsx/dist/cli.mjs tests/integration/better-sqlite3-dialect.test.ts` and it passed (prints `better-sqlite3 dialect tests passed`).
- Ran unit suite with `npm run test:unit` and all unit tests passed (`appMetadata`, smart search verification, trace tests, general settings, logo helpers).
- Could not run the full `npm test` in this container because dependency installation for some packages (`sequelize` / `better-sqlite3`) was blocked by registry/permission errors during `npm install`/`npm ci`; the patch is covered by the integration dialect test and the existing unit tests that were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060bba71288331a3f70451b19953ac)