### PR TITLE
fix: resolve better-sqlite3 Missing named parameter "1" and JSON hydration errors

### DIFF
--- a/server/betterSqlite3Dialect.ts
+++ b/server/betterSqlite3Dialect.ts
@@ -39,7 +39,43 @@ function normalizeParameters(parameters: unknown): unknown[] {
     return [];
   }
 
-  return Array.isArray(parameters) ? parameters : [parameters];
+  const mapValue = (p: unknown): unknown => {
+    if (typeof p === "boolean") return p ? 1 : 0;
+    if (p instanceof Date) return p.toISOString();
+    if (p !== null && typeof p === "object" && !Buffer.isBuffer(p)) {
+      return JSON.stringify(p);
+    }
+    if (p === undefined) return null;
+    return p;
+  };
+
+  if (Array.isArray(parameters)) {
+    return parameters.map(mapValue);
+  }
+
+  if (typeof parameters === "object" && parameters !== null) {
+    const newParams: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(parameters)) {
+      const parsedKey = key.startsWith("$") ? key.substring(1) : key;
+      const mappedValue = mapValue(value);
+      newParams[parsedKey] = mappedValue === undefined ? null : mappedValue;
+    }
+    return [newParams];
+  }
+
+  return [parameters];
+}
+
+function parseRow(row: any) {
+  if (!row) return row;
+  for (const key of Object.keys(row)) {
+    if (typeof row[key] === 'string' && (row[key].startsWith('{') || row[key].startsWith('['))) {
+      try {
+        row[key] = JSON.parse(row[key]);
+      } catch (e) {}
+    }
+  }
+  return row;
 }
 
 function extractCallback<T extends (...args: unknown[]) => void>(parameters: unknown[], callback: T | undefined): T | undefined {
@@ -127,7 +163,7 @@ export class BetterSqlite3SequelizeDatabase {
       }
 
       const row = statement.get(...normalizedParameters);
-      invokeCallback(callback, null, row);
+      invokeCallback(callback, null, parseRow(row));
     } catch (error) {
       if (isNonReturningStatementError(error)) {
         try {
@@ -163,7 +199,7 @@ export class BetterSqlite3SequelizeDatabase {
       }
 
       const rows = statement.all(...normalizedParameters);
-      invokeCallback(callback, null, rows);
+      invokeCallback(callback, null, Array.isArray(rows) ? rows.map(parseRow) : parseRow(rows));
     } catch (error) {
       if (isNonReturningStatementError(error)) {
         try {


### PR DESCRIPTION
This PR addresses the `SequelizeDatabaseError: Missing named parameter "1"` error that occurs when using the newly added `better-sqlite3` dialect mapping.

### Changes:
1. Formats `better-sqlite3` parameter bindings correctly. While standard `sqlite3` driver bindings receive parsed params automatically or tolerate object mappings under `$` prefixes natively inside Sequelize via `.map()`, `better-sqlite3` does not support Sequelize's `$`-prefixed properties in parameter objects. 
    * `server/betterSqlite3Dialect.ts` is updated to strip the `$` prefix off incoming mapping keys to accurately target placeholders `($1, $2, etc)` correctly. 
2. Correctly formats and forces primitive serialization. The `better-sqlite3` native package is strict and will only process JS primitive data types (null, string, boolean, bigint, Date/number). 
    * To accommodate JSON objects natively serialized by Sequelize, the updated dialect normalizes all arrays, dates, boolean values (to `0/1`) and deeply stringifies nested objects to be stored accurately.
3. Automatically parses return rows natively retrieved using `.get()` and `.all()` to correctly unpack previously-bound object properties stored natively as Strings. 
   * Restores compatibility and guarantees that Models stored and retrieved map effectively avoiding bugs inside of `.findAll()` where session states remained undefined instead of objects representing states effectively fixing `AdminSessions` hydration issues!

---
*PR created automatically by Jules for task [9770812333742376691](https://jules.google.com/task/9770812333742376691) started by @DrunkenHusky*