### PR TITLE
fix: better-sqlite3 sequelize dialect bindings and JSON access

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [N+1 Query Resolution]
 **Learning:** In `server/storage.ts`, the `getTrackingEntriesPaginated` function was fetching all 5000+ rules from the database using an unconstrained `findAll()` on every paginated request, just to join the rule objects to the 50 fetched tracking entries. This caused a massive N+1 style bottleneck and high memory usage.
 **Action:** Always verify how related entities are loaded in paginated endpoints. In Sequelize, extract unique related IDs (e.g., using `reduce` or `Set` over the current paginated page) and use `[Op.in]` to fetch only the required entities.
+## 2026-05-14 - [better-sqlite3 Sequelize bindings]
+**Learning:** `better-sqlite3` differs from Sequelize's native SQLite bindings in handling named parameters and boolean values. Sequelize passes named parameters with prefixes (e.g., `$1`, `$name`) and booleans directly, whereas `better-sqlite3` requires keys without prefixes and numeric equivalents (1/0) for booleans.
+**Action:** When implementing custom database dialects, ensure parameter normalization accurately translates ORM-specific formats into the target driver's expected format. Also ensure that reading database attributes relies on Sequelize's `.get('attr')` to invoke custom model getters instead of bypassing them with `.getDataValue('attr')`.

--- a/server/betterSqlite3Dialect.ts
+++ b/server/betterSqlite3Dialect.ts
@@ -39,7 +39,22 @@ function normalizeParameters(parameters: unknown): unknown[] {
     return [];
   }
 
-  return Array.isArray(parameters) ? parameters : [parameters];
+  if (Array.isArray(parameters)) {
+    return parameters;
+  }
+
+  if (typeof parameters === 'object') {
+    const normalizedObject: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(parameters)) {
+      // Sequelize sqlite dialect uses $1, $2 or $name for binding
+      // better-sqlite3 expects the parameter name without the $, @ or : prefix
+      const normalizedKey = key.replace(/^[$@:]/, '');
+      normalizedObject[normalizedKey] = typeof value === 'boolean' ? (value ? 1 : 0) : value;
+    }
+    return [normalizedObject];
+  }
+
+  return [parameters];
 }
 
 function extractCallback<T extends (...args: unknown[]) => void>(parameters: unknown[], callback: T | undefined): T | undefined {

--- a/server/databaseSessionStore.ts
+++ b/server/databaseSessionStore.ts
@@ -80,7 +80,7 @@ export class DatabaseSessionStore extends Store {
         return;
       }
 
-      callback(null, row.getDataValue('data') as SessionData);
+      callback(null, row.get('data') as SessionData);
     })().catch(error => callback(error));
   }
 
@@ -117,7 +117,7 @@ export class DatabaseSessionStore extends Store {
       await this.ensureReady();
       await this.pruneExpiredSessions();
       const rows = await AdminSessionModel.findAll();
-      callback(null, rows.map(row => row.getDataValue('data') as SessionData));
+      callback(null, rows.map(row => row.get('data') as SessionData));
     })().catch(error => callback(error));
   }
 


### PR DESCRIPTION
### What
Fixes database issues encountered after the migration to `better-sqlite3`.

### Why
- `better-sqlite3` does not expect the parameter name prefix used by Sequelize (`$`, `@`, etc.), and cannot natively bind `boolean` values.
- Direct database column queries using `.getDataValue` return raw stringified strings instead of invoking the correct custom JSON-parsing getters set on the Model.

### Impact
- Database tests for saving settings/URL rules and verifying sessions have passed.
- SQLite database interaction operates stably with the custom `better-sqlite3` dialect mapping without breaking native Sequelize features.

### Measurement
Running `npm run test` executes seamlessly. The specific failures seen in `tests/integration/database-adapter.test.ts` and `tests/integration/database-session-store.test.ts` are resolved.

---
*PR created automatically by Jules for task [5858936667120195576](https://jules.google.com/task/5858936667120195576) started by @DrunkenHusky*