### PR TITLE
fix: serialize SQLite parameters explicitly to fix JSON/Boolean object binding errors in better-sqlite3

### DIFF
--- a/server/betterSqlite3Dialect.ts
+++ b/server/betterSqlite3Dialect.ts
@@ -39,7 +39,54 @@ function normalizeParameters(parameters: unknown): unknown[] {
     return [];
   }
 
-  return Array.isArray(parameters) ? parameters : [parameters];
+  if (typeof parameters === 'object' && !Array.isArray(parameters)) {
+    const fixedParams: Record<string, unknown> = {};
+    for (const key of Object.keys(parameters as Record<string, unknown>)) {
+      let val = (parameters as Record<string, unknown>)[key];
+
+      if (typeof val === 'boolean') {
+        val = val ? 1 : 0;
+      } else if (val !== null && typeof val === 'object' && !Buffer.isBuffer(val)) {
+        if (val instanceof Date) {
+          // Serialize to ISO string as Sequelize does for Date
+          val = val.toISOString();
+        } else {
+          // Serialize object to JSON string as expected by SQLite TEXT columns
+          // but better-sqlite3 complains if we send objects directly instead of stringifying
+          val = JSON.stringify(val);
+        }
+      } else if (val === undefined) {
+        val = null;
+      }
+
+      if (key.startsWith('$') || key.startsWith('@') || key.startsWith(':')) {
+        fixedParams[key.slice(1)] = val;
+      } else {
+        fixedParams[key] = val;
+      }
+    }
+    return [fixedParams];
+  }
+
+  // Handle array case
+  if (Array.isArray(parameters)) {
+     return parameters.map(val => {
+      if (typeof val === 'boolean') {
+        return val ? 1 : 0;
+      } else if (val !== null && typeof val === 'object' && !Buffer.isBuffer(val)) {
+        if (val instanceof Date) {
+          return val.toISOString();
+        } else {
+          return JSON.stringify(val);
+        }
+      } else if (val === undefined) {
+        return null;
+      }
+      return val;
+     });
+  }
+
+  return [parameters];
 }
 
 function extractCallback<T extends (...args: unknown[]) => void>(parameters: unknown[], callback: T | undefined): T | undefined {

--- a/server/databaseSessionStore.ts
+++ b/server/databaseSessionStore.ts
@@ -80,7 +80,8 @@ export class DatabaseSessionStore extends Store {
         return;
       }
 
-      callback(null, row.getDataValue('data') as SessionData);
+      const data = row.getDataValue('data');
+      callback(null, (typeof data === 'string' ? JSON.parse(data) : data) as SessionData);
     })().catch(error => callback(error));
   }
 
@@ -117,7 +118,10 @@ export class DatabaseSessionStore extends Store {
       await this.ensureReady();
       await this.pruneExpiredSessions();
       const rows = await AdminSessionModel.findAll();
-      callback(null, rows.map(row => row.getDataValue('data') as SessionData));
+      callback(null, rows.map(row => {
+        const data = row.getDataValue('data');
+        return (typeof data === 'string' ? JSON.parse(data) : data) as SessionData;
+      }));
     })().catch(error => callback(error));
   }
 


### PR DESCRIPTION
The project was migrated from `sqlite3` to `better-sqlite3`, which led to SQL errors such as `Missing named parameter "1"` and crashes related to object/boolean/Date bindings.

The issues occurred because `Sequelize` passes positional/named parameters as objects with keys containing query prefixes (`$1`, `@2`), which `better-sqlite3` rejects (it expects the key to be un-prefixed, e.g. `1`). Further, `better-sqlite3` only supports binding strict types like strings, numbers, or `null`. Unlike `sqlite3`, it doesn't gracefully stringify Dates, JSON objects, or cast booleans natively if provided via an object.

This fix:
1. Updates `normalizeParameters` inside `server/betterSqlite3Dialect.ts` to automatically strip `$`, `@`, or `:` characters from object parameter keys.
2. Formats unsupported parameter values before binding (e.g., parses booleans to integers, maps Dates to `.toISOString()`, and uses `JSON.stringify` for raw objects).
3. Adapts JSON parsing logic when retrieving stringified rows in `databaseSessionStore.ts` to handle double-serialization scenarios safely.

All unit and integration tests successfully pass.

---
*PR created automatically by Jules for task [42929146227150721](https://jules.google.com/task/42929146227150721) started by @DrunkenHusky*