### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV Formula Injection in Export

### DIFF
--- a/server/import-export.ts
+++ b/server/import-export.ts
@@ -317,7 +317,7 @@ export class ImportExportService {
    * @param value The value to sanitize
    * @returns Sanitized value
    */
-  private static sanitizeForCSV(value: any): any {
+  public static sanitizeForCSV(value: any): any {
     if (typeof value === 'string') {
       // Prevent formula injection (CSV Injection)
       // If string starts with =, +, -, or @, prepend a single quote

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -950,10 +950,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
             const feedback = track.feedback || '';
             const quality = track.matchQuality !== undefined ? track.matchQuality : 0;
             const userProposedUrl = track.userProposedUrl || '';
+
+            // Sanitize user-controlled strings to prevent CSV/Formula injection
+            const sOldUrl = ImportExportService.sanitizeForCSV(track.oldUrl);
+            const sNewUrl = ImportExportService.sanitizeForCSV((track as any).newUrl || '');
+            const sPath = ImportExportService.sanitizeForCSV(track.path);
+            const sReferrer = ImportExportService.sanitizeForCSV(track.referrer || '');
+            const sUserAgent = ImportExportService.sanitizeForCSV(track.userAgent || '');
+            const sFeedback = ImportExportService.sanitizeForCSV(feedback);
+            const sUserProposedUrl = ImportExportService.sanitizeForCSV(userProposedUrl);
+
             if (includeReferrer) {
-              return `"${track.id}","${track.oldUrl}","${(track as any).newUrl || ''}","${track.path}","${track.referrer || ''}","${track.timestamp}","${track.userAgent || ''}","${ruleId}","${feedback}","${quality}","${userProposedUrl}"`;
+              return `"${track.id}","${sOldUrl}","${sNewUrl}","${sPath}","${sReferrer}","${track.timestamp}","${sUserAgent}","${ruleId}","${sFeedback}","${quality}","${sUserProposedUrl}"`;
             } else {
-              return `"${track.id}","${track.oldUrl}","${(track as any).newUrl || ''}","${track.path}","${track.timestamp}","${track.userAgent || ''}","${ruleId}","${feedback}","${quality}","${userProposedUrl}"`;
+              return `"${track.id}","${sOldUrl}","${sNewUrl}","${sPath}","${track.timestamp}","${sUserAgent}","${ruleId}","${sFeedback}","${quality}","${sUserProposedUrl}"`;
             }
           }).join('\n');
           


### PR DESCRIPTION
**Severity:** HIGH
**Vulnerability:** The tracking data export endpoint at `/api/admin/export` was directly embedding user-controlled inputs (such as URLs, referrers, and user agents) into the exported CSV format without sanitization. An attacker or malicious user could inject spreadsheet formulas (e.g., `=1+1`) within these fields, potentially leading to arbitrary code execution or data exfiltration when opened by an administrator in applications like Microsoft Excel or Google Sheets.
**Impact:** Malicious formulas could be executed on the machine of the administrator viewing the exported tracking data.
**Fix:** Refactored `ImportExportService.sanitizeForCSV` to be publicly accessible, and applied it to all user-controlled variables in the tracking export data mapping loop inside `server/routes.ts`.
**Verification:** Validated that the tests (via `npm run test:unit`) continue to pass. Verified the logic processes `track.oldUrl` and similar fields via `ImportExportService.sanitizeForCSV()`.

---
*PR created automatically by Jules for task [4642269594524411294](https://jules.google.com/task/4642269594524411294) started by @DrunkenHusky*