### PR TITLE
⚡ Bolt: [performance improvement] DB Pagination for Top URLs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [N+1 Query Resolution]
 **Learning:** In `server/storage.ts`, the `getTrackingEntriesPaginated` function was fetching all 5000+ rules from the database using an unconstrained `findAll()` on every paginated request, just to join the rule objects to the 50 fetched tracking entries. This caused a massive N+1 style bottleneck and high memory usage.
 **Action:** Always verify how related entities are loaded in paginated endpoints. In Sequelize, extract unique related IDs (e.g., using `reduce` or `Set` over the current paginated page) and use `[Op.in]` to fetch only the required entities.
+## 2026-05-21 - [Database-Level Pagination for Grouped Queries]
+**Learning:** In `server/storage.ts`, `getTopUrlsPaginated` was fetching all top URLs using `this.getTopUrls(10000)` and then slicing the array in memory for pagination. This bypassed the database's ability to limit result sets, leading to high CPU and memory usage as the database grew.
+**Action:** Always implement pagination at the database level using `limit` and `offset` within `findAll` (or similar query methods). For aggregated queries (like `GROUP BY path`), compute the total count of distinct groups using a `count({ distinct: true, col: 'path' })` query to correctly calculate the total number of pages.

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -914,13 +914,44 @@ export class FileStorage implements IStorage {
     limit: number,
     timeRange: "24h" | "7d" | "all" = "all",
   ) {
-    const urls = await this.getTopUrls(10000, timeRange);
-    const total = urls.length;
-    const startIndex = (page - 1) * limit;
-    const endIndex = Math.min(startIndex + limit, total);
+    await this.ensureDbReady();
+
+    const whereClause: any = {
+      ...this.buildTrackingTimeRangeWhere(timeRange),
+      path: {
+        [Op.notIn]: ['/', '/?admin=true', '/?logout=true']
+      },
+    };
+
+    const offset = (page - 1) * limit;
+
+    // ⚡ Bolt Performance Optimization:
+    // Implemented pagination at the database level rather than fetching
+    // all records into Node.js memory. The distinct count ensures accurate
+    // total calculation for pagination math while drastically reducing DB
+    // load and transferring minimal data over the network.
+    const total = await UrlTrackingModel.count({
+      where: whereClause,
+      distinct: true,
+      col: 'path'
+    });
+
+    const rows = await UrlTrackingModel.findAll({
+      attributes: ['path', [sequelize.fn('COUNT', sequelize.col('path')), 'count']],
+      where: whereClause,
+      group: ['path'],
+      order: [[sequelize.col('count'), 'DESC']],
+      limit,
+      offset
+    });
+
+    const urls = rows.map(r => ({
+      path: r.getDataValue('path'),
+      count: Number.parseInt(String(r.getDataValue('count')), 10)
+    }));
 
     return {
-      urls: urls.slice(startIndex, endIndex),
+      urls,
       total,
       totalPages: Math.ceil(total / limit),
       currentPage: page,


### PR DESCRIPTION
💡 What: Implemented database-level pagination in `getTopUrlsPaginated` using limit and offset, paired with a DISTINCT count query, rather than fetching up to 10,000 top URLs into memory and slicing.

🎯 Why: The original approach of fetching all aggregated data just to calculate a slice was very memory and CPU intensive (an N+1 style bottleneck for aggregations), leading to degraded performance as URL tracking metrics scaled.

📊 Impact: Significantly reduces DB load and limits data transferred over the network to exactly the page size (e.g. 50 records) plus a single numeric count.

🔬 Measurement: Verifiable by executing test cases for adapter APIs or observing database CPU / NodeJS memory usage metrics during large load on the admin dashboard's statistics tabs.

---
*PR created automatically by Jules for task [12029531148188820828](https://jules.google.com/task/12029531148188820828) started by @DrunkenHusky*