### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV/Formula Injection in manual exports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** A path traversal vulnerability was discovered in `server/fileSessionStore.ts`. The session ID (`sid`) was used directly without any validation to construct the path of session files using `path.join()`. This could allow an attacker to traverse the file system by providing a `sid` containing `../`.
 **Learning:** Even internal mechanisms like session storage require input validation when user-controlled data (like cookies) are used in file paths.
 **Prevention:** Implemented path validation to reject traversal characters (`/`, `\`, `..`), sanitized the input by stripping non-alphanumeric characters, and added a defense-in-depth check using `path.resolve()` and `.startsWith()` to ensure the final path strictly resides inside the expected session directory.
+
+## 2025-06-04 - CSV/Formula Injection in Manual CSV Generation
+**Vulnerability:** The application manually generated CSV exports (e.g., statistics export) using template literals (`return \`"\${track.id}","\${track.oldUrl}"...\``) without properly escaping double quotes (`"`) or sanitizing formulas. This allowed CSV injection and Formula Injection.
+**Learning:** Even if a `sanitizeForCSV` function exists for one module (`ImportExportService`), manual string concatenation in other routes can bypass these protections.
+**Prevention:** Reused `ImportExportService.sanitizeForCSV` globally by making it public and wrapping all user-controlled values during manual CSV generation. Also correctly implemented double-quote escaping (`""`) for manual CSV building.

--- a/server/import-export.ts
+++ b/server/import-export.ts
@@ -317,7 +317,7 @@ export class ImportExportService {
    * @param value The value to sanitize
    * @returns Sanitized value
    */
-  private static sanitizeForCSV(value: any): any {
+  public static sanitizeForCSV(value: any): any {
     if (typeof value === 'string') {
       // Prevent formula injection (CSV Injection)
       // If string starts with =, +, -, or @, prepend a single quote

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -742,7 +742,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const ips = await getBlockedIps();
 
       const data = ips.map(entry => ({
-        IP: entry.ip,
+        IP: ImportExportService.sanitizeForCSV(entry.ip),
         Attempts: entry.attempts,
         BlockedUntil: entry.blockedUntil ? new Date(entry.blockedUntil).toISOString() : ''
       }));
@@ -944,6 +944,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
             ? 'ID,Alte URL,Neue URL,Pfad,Referrer,Zeitstempel,User-Agent,Regel ID,Feedback,Qualität,Benutzervorschlag,Strategie,Globale Regeln\n'
             : 'ID,Alte URL,Neue URL,Pfad,Zeitstempel,User-Agent,Regel ID,Feedback,Qualität,Benutzervorschlag,Strategie,Globale Regeln\n';
 
+          const escapeCSV = (val: any) => {
+            if (val == null) return '""';
+            const sanitized = ImportExportService.sanitizeForCSV(val);
+            const str = String(sanitized);
+            // Escape double quotes by doubling them
+            return `"${str.replace(/"/g, '""')}"`;
+          };
+
           const csvData = trackingData.map(track => {
             // Prepare new fields
             const ruleId = track.ruleId || (track.ruleIds && track.ruleIds.length > 0 ? track.ruleIds.join(';') : '') || '';
@@ -951,9 +959,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
             const quality = track.matchQuality !== undefined ? track.matchQuality : 0;
             const userProposedUrl = track.userProposedUrl || '';
             if (includeReferrer) {
-              return `"${track.id}","${track.oldUrl}","${(track as any).newUrl || ''}","${track.path}","${track.referrer || ''}","${track.timestamp}","${track.userAgent || ''}","${ruleId}","${feedback}","${quality}","${userProposedUrl}"`;
+              return `${escapeCSV(track.id)},${escapeCSV(track.oldUrl)},${escapeCSV((track as any).newUrl || '')},${escapeCSV(track.path)},${escapeCSV(track.referrer || '')},${escapeCSV(track.timestamp)},${escapeCSV(track.userAgent || '')},${escapeCSV(ruleId)},${escapeCSV(feedback)},${escapeCSV(quality)},${escapeCSV(userProposedUrl)}`;
             } else {
-              return `"${track.id}","${track.oldUrl}","${(track as any).newUrl || ''}","${track.path}","${track.timestamp}","${track.userAgent || ''}","${ruleId}","${feedback}","${quality}","${userProposedUrl}"`;
+              return `${escapeCSV(track.id)},${escapeCSV(track.oldUrl)},${escapeCSV((track as any).newUrl || '')},${escapeCSV(track.path)},${escapeCSV(track.timestamp)},${escapeCSV(track.userAgent || '')},${escapeCSV(ruleId)},${escapeCSV(feedback)},${escapeCSV(quality)},${escapeCSV(userProposedUrl)}`;
             }
           }).join('\n');
           


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix CSV and Formula Injection in manual exports

🚨 Severity: HIGH
💡 Vulnerability: The `/api/admin/export` statistics endpoint manually constructed CSV files using template literals without properly escaping double quotes (`"`) or preventing formulas (`=1+1`). This could lead to CSV Injection, where a malicious URL or user agent breaks the CSV format or causes Excel/Sheets to execute formulas.
🎯 Impact: An attacker could perform data exfiltration or execute malicious formulas if an administrator exports statistics and opens the resulting file in spreadsheet software.
🔧 Fix: Refactored `ImportExportService.sanitizeForCSV` to be `public` and wrapped all dynamically inserted, user-controlled strings in the manual statistics export and blocked IP export logic. Added robust escaping of inner double quotes.
✅ Verification: Ran the full integration and unit test suite successfully without any regressions.

---
*PR created automatically by Jules for task [1067310564422839069](https://jules.google.com/task/1067310564422839069) started by @DrunkenHusky*