### PR TITLE
⚡ Bolt: [performance improvement] concurrent db queries in stats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [N+1 Query Resolution]
 **Learning:** In `server/storage.ts`, the `getTrackingEntriesPaginated` function was fetching all 5000+ rules from the database using an unconstrained `findAll()` on every paginated request, just to join the rule objects to the 50 fetched tracking entries. This caused a massive N+1 style bottleneck and high memory usage.
 **Action:** Always verify how related entities are loaded in paginated endpoints. In Sequelize, extract unique related IDs (e.g., using `reduce` or `Set` over the current paginated page) and use `[Op.in]` to fetch only the required entities.
+## 2025-05-24 - [Concurrent Database Aggregations]
+**Learning:** Sequential `await` calls for independent database queries (e.g., multiple `.count()` queries in stats endpoints) create a significant performance bottleneck due to sequential network and DB roundtrip latency.
+**Action:** Always group independent, non-dependent queries using `Promise.all` to fetch data concurrently, especially when computing metrics or aggregations for dashboards.

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -683,18 +683,30 @@ export class FileStorage implements IStorage {
     const lastWeek = new Date(today);
     lastWeek.setDate(today.getDate() - 7);
 
-    const total = await UrlTrackingModel.count();
-    const todayCount = await UrlTrackingModel.count({ where: { timestamp: { [Op.gte]: today.toISOString() } } });
-    const weekCount = await UrlTrackingModel.count({ where: { timestamp: { [Op.gte]: lastWeek.toISOString() } } });
-
-    const match100 = await UrlTrackingModel.count({ where: { matchQuality: 100 } });
-    const match75 = await UrlTrackingModel.count({ where: { matchQuality: { [Op.gte]: 75, [Op.lt]: 100 } } });
-    const match50 = await UrlTrackingModel.count({ where: { matchQuality: { [Op.gte]: 50, [Op.lt]: 75 } } });
-    const match0 = await UrlTrackingModel.count({ where: { matchQuality: { [Op.lt]: 50 } } });
-
-    const ok = await UrlTrackingModel.count({ where: { feedback: 'OK' } });
-    const nok = await UrlTrackingModel.count({ where: { feedback: 'NOK' } });
-    const autoRedirect = await UrlTrackingModel.count({ where: { feedback: 'auto-redirect' } });
+    // Optimize: Fetch all independent counts concurrently to reduce sequential DB roundtrips latency.
+    const [
+      total,
+      todayCount,
+      weekCount,
+      match100,
+      match75,
+      match50,
+      match0,
+      ok,
+      nok,
+      autoRedirect
+    ] = await Promise.all([
+      UrlTrackingModel.count(),
+      UrlTrackingModel.count({ where: { timestamp: { [Op.gte]: today.toISOString() } } }),
+      UrlTrackingModel.count({ where: { timestamp: { [Op.gte]: lastWeek.toISOString() } } }),
+      UrlTrackingModel.count({ where: { matchQuality: 100 } }),
+      UrlTrackingModel.count({ where: { matchQuality: { [Op.gte]: 75, [Op.lt]: 100 } } }),
+      UrlTrackingModel.count({ where: { matchQuality: { [Op.gte]: 50, [Op.lt]: 75 } } }),
+      UrlTrackingModel.count({ where: { matchQuality: { [Op.lt]: 50 } } }),
+      UrlTrackingModel.count({ where: { feedback: 'OK' } }),
+      UrlTrackingModel.count({ where: { feedback: 'NOK' } }),
+      UrlTrackingModel.count({ where: { feedback: 'auto-redirect' } })
+    ]);
 
     // We get missing feedback by taking total and subtracting others.
     // Not perfect but robust without complex IS NULL queries across dialects


### PR DESCRIPTION
💡 What: Refactored the `getTrackingStats` function in `server/storage.ts` to run 10 independent database `count()` queries concurrently using `Promise.all` instead of awaiting them sequentially.
🎯 Why: Awaiting 10 non-dependent database queries sequentially created a performance bottleneck due to cumulative sequential network/database round-trip latency. This is an N+1 style bottleneck.
📊 Impact: Reduces the time spent fetching stats data significantly, improving the dashboard/metrics API response time as all 10 queries will complete in roughly the time of the single slowest query, instead of the sum of all 10.
🔬 Measurement: Verify by loading the stats API endpoint; the overall execution time should be measurably reduced. Additionally, all tests run successfully, confirming the data returned is still accurate.

---
*PR created automatically by Jules for task [11730330194014066290](https://jules.google.com/task/11730330194014066290) started by @DrunkenHusky*