### PR TITLE
⚡ Bolt: [performance improvement] Optimize memory usage for getTopReferrers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [N+1 Query Resolution]
 **Learning:** In `server/storage.ts`, the `getTrackingEntriesPaginated` function was fetching all 5000+ rules from the database using an unconstrained `findAll()` on every paginated request, just to join the rule objects to the 50 fetched tracking entries. This caused a massive N+1 style bottleneck and high memory usage.
 **Action:** Always verify how related entities are loaded in paginated endpoints. In Sequelize, extract unique related IDs (e.g., using `reduce` or `Set` over the current paginated page) and use `[Op.in]` to fetch only the required entities.
+
+## 2025-02-18 - Optimized getTopReferrers Database Queries
+**Learning:** In Sequelize, running aggregate operations entirely in memory on objects returned by `findAll()` without specifying `attributes` leads to loading the entire table rows into memory (which can be huge for tracking data).
+**Action:** When implementing aggregate queries like `getTopReferrers`, restrict fetched columns using the `attributes` option (e.g. `['referrer']`) and use `raw: true` in `findAll()` queries to skip expensive model instantiation and drastically reduce memory footprint when the full model instance is not required.

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -612,7 +612,12 @@ export class FileStorage implements IStorage {
   ) {
     await this.ensureDbReady();
 
-    let whereClause = {};
+    let whereClause: any = {
+      referrer: {
+        [Op.and]: [{ [Op.ne]: null }, { [Op.ne]: '' }]
+      }
+    };
+
     if (timeRange !== "all") {
       const now = new Date();
       const timeLimit = new Date(now);
@@ -621,15 +626,16 @@ export class FileStorage implements IStorage {
       } else if (timeRange === "7d") {
         timeLimit.setDate(now.getDate() - 7);
       }
-      whereClause = {
-        timestamp: { [Op.gte]: timeLimit.toISOString() }
-      };
+      whereClause.timestamp = { [Op.gte]: timeLimit.toISOString() };
     }
 
-    const trackingData = await UrlTrackingModel.findAll({ where: whereClause });
-    const referrers = trackingData
-      .map(r => r.getDataValue('referrer'))
-      .filter((r) => r && r.length > 0);
+    const trackingData = await UrlTrackingModel.findAll({
+      attributes: ['referrer'],
+      where: whereClause,
+      raw: true
+    });
+
+    const referrers = trackingData.map((r: any) => r.referrer);
 
     const domains: Record<string, number> = {};
     for (const ref of referrers) {


### PR DESCRIPTION
💡 **What:** Optimized the `getTopReferrers` method in `server/storage.ts` by restricting the database query to fetch only the `referrer` column and returning raw JavaScript objects. It also pushes the `null`/empty filter down to the database level using `Op.ne`.

🎯 **Why:** Previously, the query loaded all columns of the `UrlTrackingModel` for all matching rows, creating full Sequelize model instances in memory just to map them to strings immediately. For large tracking tables, this causes significant unnecessary memory allocation and CPU overhead.

📊 **Impact:** Substantially reduces the memory footprint and network transfer size when querying top referrers, especially as the number of tracking entries grows over time.

🔬 **Measurement:** Verify by navigating to the Admin "Statistics" dashboard and loading the "Top Referrers" section; observe the memory usage and query execution time (which should now be much faster for thousands of entries). Run `npm run test` to confirm regressions aren't introduced.

---
*PR created automatically by Jules for task [281389577891269899](https://jules.google.com/task/281389577891269899) started by @DrunkenHusky*