### PR TITLE
test: align runtime baseline with npm >=11.3

### DIFF
--- a/tests/shared/dependency-security.test.ts
+++ b/tests/shared/dependency-security.test.ts
@@ -12,7 +12,6 @@ interface PackageLock {
 
 interface PackageManifest {
   engines?: Record<string, string>;
-  overrides?: Record<string, string>;
 }
 
 const packageLock = JSON.parse(
@@ -60,7 +59,6 @@ test("the lockfile resolves every audited package to a secure version", async (c
   }
 });
 
-test("the supported runtime and qs override match the maintenance baseline", () => {
-  assert.deepEqual(packageManifest.engines, { node: ">=24.10.0", npm: ">=11" });
-  // assert.equal(packageManifest.overrides?.qs, "6.16.0");
+test("the supported runtime matches the maintenance baseline", () => {
+  assert.deepEqual(packageManifest.engines, { node: ">=24.10.0", npm: ">=11.3" });
 });


### PR DESCRIPTION
### Motivation

- Die Tests mussten an die aktualisierten Engine-Anforderungen in `package.json` angepasst werden, nachdem die Abhängigkeiten und die Lockfile-Aktualisierung die npm-Anforderung auf `>=11.3` erhöht haben. 
- Ein veralteter, unbenutzter `overrides`-Verweis im Test wurde entfernt, weil er nicht mehr relevant ist.

### Description

- Aktualisiert `tests/shared/dependency-security.test.ts` und erwartet nun `engines` mit `{ node: ">=24.10.0", npm: ">=11.3" }` anstelle von `npm: ">=11"`.
- Entfernt die nicht genutzte `overrides?: Record<string,string>`-Deklaration aus dem `PackageManifest`-Interface und passt die Testbeschreibung auf `the supported runtime matches the maintenance baseline` an.
- Änderungen wurden als Test-Änderung committed (Conventional Commit: `test: align runtime baseline with npm requirement`).

### Testing

- `npm test` wurde ausgeführt und alle Test-Suites sind bestanden (`11 passed, 0 failed`).
- `npx tsx tests/shared/dependency-security.test.ts` wurde einzeln ausgeführt und erfolgreich bestanden.
- `npm run build` wurde ausgeführt und das Projekt wurde gebaut, wobei Vite lediglich eine Chunk-Größen-Warnung ausgab; der Build war erfolgreich.
- `npm audit --audit-level=high` scheiterte an einem Registry-Audit-Endpoint mit HTTP `403 Forbidden`, jedoch hat die lokale Lockfile-Prüfung in den Tests alle geprüften Pakete als mindestens die erwarteten sicheren Versionen bestätigt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9fb77a961083319487e7c416a6b807)