### PR TITLE
fix: update npm engine version in dependency-security tests

### DIFF
--- a/tests/shared/dependency-security.test.ts
+++ b/tests/shared/dependency-security.test.ts
@@ -61,6 +61,6 @@ test("the lockfile resolves every audited package to a secure version", async (c
 });
 
 test("the supported runtime and qs override match the maintenance baseline", () => {
-  assert.deepEqual(packageManifest.engines, { node: ">=24.10.0", npm: ">=11" });
+  assert.deepEqual(packageManifest.engines, { node: ">=24.10.0", npm: ">=11.3" });
   // assert.equal(packageManifest.overrides?.qs, "6.16.0");
 });


### PR DESCRIPTION
I've updated the `tests/shared/dependency-security.test.ts` file to assert `npm: ">=11.3"` instead of `>=11`, to match the newly required `npm` version inside `package.json`. Tests are passing again.

---
*PR created automatically by Jules for task [15621147579863192187](https://jules.google.com/task/15621147579863192187) started by @DrunkenHusky*