### PR TITLE
fix(admin): optimize responsive mobile layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Mit diesem Endpoint können Sie eine alte URL übergeben und erhalten die entspr
 ## Administration
 
 Der Admin-Bereich lässt sich über das Zahnrad-Symbol oben rechts oder direkt über den URL-Parameter `?admin=true` öffnen.
+Die Navigation, Regelverwaltung und Bearbeitungsdialoge sind für Smartphones optimiert; Aktionsschaltflächen bleiben gut lesbar und besitzen ausreichend große Touch-Ziele.
 
 ### Regeln importieren
 

--- a/client/src/components/admin/GlobalRulesSettings.tsx
+++ b/client/src/components/admin/GlobalRulesSettings.tsx
@@ -117,13 +117,13 @@ export function GlobalRulesSettings({ settings, onUpdate, onSave, isSaving, onOp
     <div className="space-y-6">
         <Card>
             <CardHeader>
-                <div className="flex items-center justify-between">
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                     <Globe className="h-5 w-5 text-blue-600" />
                     <CardTitle>Globale Regeln</CardTitle>
                     </div>
                     {onOpenValidation && (
-                        <Button variant="outline" size="sm" onClick={onOpenValidation} className="gap-2">
+                        <Button variant="outline" size="sm" onClick={onOpenValidation} className="gap-2 w-full sm:w-auto min-h-11 h-auto whitespace-normal">
                             <RefreshCw className="h-4 w-4" />
                             Konfigurationsvalidierung
                         </Button>
@@ -149,7 +149,7 @@ export function GlobalRulesSettings({ settings, onUpdate, onSave, isSaving, onOp
                     <div className="space-y-3">
                         {(settings.globalSearchAndReplace || []).map((item, index) => (
                             <div key={item.id} className="flex flex-col gap-2 p-3 bg-muted/30 rounded border">
-                                <div className="flex gap-2 items-end">
+                                <div className="admin-editor-row flex flex-col sm:flex-row gap-2 sm:items-end">
                                     <div className="flex-1 space-y-1">
                                         <label className="text-xs font-medium block">Suchen</label>
                                         <Input
@@ -195,7 +195,7 @@ export function GlobalRulesSettings({ settings, onUpdate, onSave, isSaving, onOp
                                 </div>
                             </div>
                         ))}
-                        <Button variant="outline" size="sm" onClick={handleAddSearchReplace} className="gap-2">
+                        <Button variant="outline" size="sm" onClick={handleAddSearchReplace} className="gap-2 w-full sm:w-auto">
                             <Plus className="h-3 w-3" /> Hinzufügen
                         </Button>
                     </div>
@@ -214,7 +214,7 @@ export function GlobalRulesSettings({ settings, onUpdate, onSave, isSaving, onOp
                      <div className="space-y-3">
                         {(settings.globalStaticQueryParams || []).map((item, index) => (
                             <div key={item.id} className="flex flex-col gap-2 p-3 bg-muted/30 rounded border">
-                                <div className="flex gap-2 items-end">
+                                <div className="admin-editor-row flex flex-col sm:flex-row gap-2 sm:items-end">
                                     <div className="flex-1 space-y-1">
                                         <label className="text-xs font-medium block">Key</label>
                                         <Input
@@ -260,7 +260,7 @@ export function GlobalRulesSettings({ settings, onUpdate, onSave, isSaving, onOp
                                 </div>
                             </div>
                         ))}
-                        <Button variant="outline" size="sm" onClick={handleAddStaticParam} className="gap-2">
+                        <Button variant="outline" size="sm" onClick={handleAddStaticParam} className="gap-2 w-full sm:w-auto">
                             <Plus className="h-3 w-3" /> Hinzufügen
                         </Button>
                     </div>
@@ -279,7 +279,7 @@ export function GlobalRulesSettings({ settings, onUpdate, onSave, isSaving, onOp
                     <div className="space-y-3">
                         {(settings.globalKeptQueryParams || []).map((item, index) => (
                             <div key={item.id} className="flex flex-col gap-2 p-3 bg-muted/30 rounded border">
-                                <div className="flex gap-2 items-end">
+                                <div className="admin-editor-row flex flex-col sm:flex-row gap-2 sm:items-end">
                                     <div className="flex-1 space-y-1">
                                         <label className="text-xs font-medium block">Key Pattern (Regex)</label>
                                         <Input
@@ -326,7 +326,7 @@ export function GlobalRulesSettings({ settings, onUpdate, onSave, isSaving, onOp
                                 </div>
                             </div>
                         ))}
-                        <div className="flex gap-2">
+                        <div className="flex flex-col sm:flex-row gap-2">
                             <Button variant="outline" size="sm" onClick={handleAddKeptParam} className="gap-2">
                                 <Plus className="h-3 w-3" /> Hinzufügen
                             </Button>

--- a/client/src/components/ui/alert-dialog.tsx
+++ b/client/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-1rem)] max-w-lg max-h-[calc(100dvh-1rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:w-full sm:p-6 sm:rounded-lg",
         className
       )}
       {...props}
@@ -63,7 +63,7 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end [&_button]:min-h-11 [&_button]:w-full sm:[&_button]:w-auto",
       className
     )}
     {...props}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-1rem)] max-w-lg max-h-[calc(100dvh-1rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:w-full sm:p-6 sm:rounded-lg",
         className
       )}
       {...props}
@@ -73,7 +73,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end [&_button]:min-h-11 [&_button]:w-full sm:[&_button]:w-auto",
       className
     )}
     {...props}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -83,6 +83,18 @@
 }
 
 @media (max-width: 640px) {
+  .admin-shell {
+    max-width: 100%;
+    overflow-x: clip;
+  }
+
+  .admin-shell main,
+  .admin-shell form,
+  .admin-shell [role="tabpanel"] {
+    min-width: 0;
+    max-width: 100%;
+  }
+
   .admin-shell .rounded-lg.border.bg-card > div[class*="p-6"] {
     padding-left: 1rem;
     padding-right: 1rem;
@@ -92,10 +104,31 @@
   .admin-shell textarea,
   .admin-shell button[role="combobox"] {
     font-size: 16px;
+    max-width: 100%;
   }
 
-  .admin-shell .admin-editor-row > * {
+  .admin-shell .admin-editor-row > *,
+  .admin-shell .admin-rule-editor-row > * {
     min-width: 0;
     width: 100%;
+  }
+
+  .admin-rule-form input,
+  .admin-rule-form textarea,
+  .admin-rule-form button[role="combobox"],
+  .admin-editor-row input {
+    min-height: 44px;
+    width: 100%;
+  }
+
+  .admin-rule-form textarea {
+    min-height: 96px;
+  }
+
+  .admin-rule-form .admin-add-actions button {
+    min-height: 44px;
+    width: 100%;
+    height: auto;
+    white-space: normal;
   }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -81,3 +81,21 @@
     transform: translateY(-1px);
   }
 }
+
+@media (max-width: 640px) {
+  .admin-shell .rounded-lg.border.bg-card > div[class*="p-6"] {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .admin-shell input,
+  .admin-shell textarea,
+  .admin-shell button[role="combobox"] {
+    font-size: 16px;
+  }
+
+  .admin-shell .admin-editor-row > * {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -1928,7 +1928,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
   };
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="admin-shell min-h-screen bg-background">
       {/* Mobile-Friendly Admin Header */}
       <header className="bg-surface shadow-sm border-b border-border">
         <div className="max-w-6xl mx-auto px-3 sm:px-4 py-3 sm:py-4">
@@ -1970,12 +1970,12 @@ export default function AdminPage({ onClose }: AdminPageProps) {
       </header>
 
       {/* Mobile-Optimized Admin Content */}
-      <main className="py-4 sm:py-8 px-3 sm:px-4 ">
+      <main className="py-3 sm:py-8 px-2 sm:px-4">
         <div className="max-w-6xl mx-auto w-full">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-4 sm:space-y-6">
             {/* Enhanced Tab Navigation */}
             <div className="w-full overflow-hidden">
-              <TabsList className="grid w-full grid-cols-5 h-auto">
+              <TabsList className="grid w-full grid-cols-3 sm:grid-cols-5 h-auto gap-1">
                 <TabsTrigger value="general" className="flex flex-col sm:flex-row items-center justify-center space-y-1 sm:space-y-0 sm:space-x-2 py-3 px-1 sm:px-3 text-xs sm:text-sm min-h-[56px] sm:min-h-[48px]">
                   <FileText className="h-3 w-3 sm:h-4 sm:w-4" />
                   <span className="truncate leading-tight text-center">Allgemein</span>
@@ -3558,7 +3558,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                         Verwalten Sie URL-Transformations-Regeln für die Migration.
                       </p>
                     </div>
-                    <div className="flex gap-2 w-full sm:w-auto">
+                    <div className="admin-rule-actions grid grid-cols-1 min-[420px]:grid-cols-2 gap-2 w-full sm:flex sm:w-auto">
                       {/* Bulk Delete Button */}
                       {selectedRuleIds.length > 0 && (
                         <Button 
@@ -3576,7 +3576,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                       <Button
                         variant="outline"
                         size="sm"
-                        className="flex-1 sm:flex-initial sm:w-auto"
+                        className="min-h-11 h-auto whitespace-normal px-3 flex-1 sm:flex-initial sm:w-auto"
                         onClick={() => setShowValidationModal(true)}
                       >
                          <RefreshCw className="h-4 w-4 mr-2" />
@@ -3591,7 +3591,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                           setIsRuleDialogOpen(true);
                         }}
                         size="sm"
-                        className="flex-1 sm:flex-initial sm:w-auto"
+                        className="min-h-11 h-auto whitespace-normal px-3 flex-1 sm:flex-initial sm:w-auto"
                       >
                         <Plus className="h-4 w-4 mr-2" />
                         Neue Regel
@@ -4855,7 +4855,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
 
       {/* Rule Editing Dialog - Moved outside TabsContent to be accessible from all tabs */}
       <Dialog open={isRuleDialogOpen} onOpenChange={setIsRuleDialogOpen}>
-        <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
+        <DialogContent className="sm:max-w-[620px] max-h-[calc(100dvh-1rem)] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-lg sm:text-xl">
               {editingRule ? "Regel bearbeiten" : "Neue Regel erstellen"}
@@ -5431,11 +5431,11 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                 </div>
               </div>
             </div>
-            <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-3">
+            <div className="admin-dialog-actions sticky bottom-0 z-10 flex flex-col sm:flex-row gap-2 bg-background border-t pt-3 pb-[max(0.25rem,env(safe-area-inset-bottom))] -mx-1 px-1">
               <Button
                 type="submit"
                 className="flex-1"
-                size="sm"
+                size="lg"
                 disabled={createRuleMutation.isPending || updateRuleMutation.isPending}
               >
                 {editingRule ? "Aktualisieren" : "Erstellen"}
@@ -5443,7 +5443,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
               <Button
                 type="button"
                 variant="secondary"
-                size="sm"
+                size="lg"
                 className="flex-1"
                 onClick={() => setIsRuleDialogOpen(false)}
               >

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -4864,7 +4864,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
               {editingRule ? "Bearbeiten Sie die existierende Regel hier." : "Erstellen Sie hier eine neue Regel."}
             </DialogDescription>
           </DialogHeader>
-          <form onSubmit={handleSubmitRule} className="space-y-4 sm:space-y-6">
+          <form onSubmit={handleSubmitRule} className="admin-rule-form min-w-0 space-y-4 sm:space-y-6">
             <div>
               <label className="block text-sm font-medium mb-2">
                 URL-Pfad Matcher
@@ -4955,7 +4955,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                 <div className="space-y-3">
                   {ruleForm.searchAndReplace.map((item, index) => (
                     <div key={index} className="flex flex-col gap-2 p-2 bg-muted/30 rounded border">
-                      <div className="flex gap-2 items-end">
+                      <div className="admin-rule-editor-row flex flex-col sm:flex-row gap-2 sm:items-end">
                         <div className="flex-1 space-y-1">
                             <label className="text-xs font-medium block h-8 flex items-end pb-1">Suchen</label>
                             <Input
@@ -5052,7 +5052,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                     </div>
                   ))}
 
-                  <div className="flex gap-2 mt-2">
+                  <div className="admin-add-actions flex flex-col sm:flex-row gap-2 mt-2">
                     <Button
                         type="button"
                         variant="outline"
@@ -5086,7 +5086,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                     <div className="space-y-3">
                       {ruleForm.staticQueryParams.map((item, index) => (
                         <div key={index} className="flex flex-col gap-2 p-2 bg-muted/30 rounded border">
-                          <div className="flex gap-2 items-end">
+                          <div className="admin-rule-editor-row flex flex-col sm:flex-row gap-2 sm:items-end">
                             <div className="flex-1 space-y-1">
                                 <label className="text-xs font-medium block h-8 flex items-end pb-1">Key</label>
                                 <Input
@@ -5184,7 +5184,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                         </div>
                       ))}
 
-                      <div className="flex gap-2 mt-2">
+                      <div className="admin-add-actions flex flex-col sm:flex-row gap-2 mt-2">
                         <Button
                             type="button"
                             variant="outline"
@@ -5258,7 +5258,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                     <div className="space-y-3">
                       {ruleForm.keptQueryParams.map((item, index) => (
                         <div key={index} className="flex flex-col gap-2 p-2 bg-muted/30 rounded border">
-                          <div className="flex gap-2 items-end">
+                          <div className="admin-rule-editor-row flex flex-col sm:flex-row gap-2 sm:items-end">
                             <div className="flex-1 space-y-1">
                                 <label className="text-xs font-medium block h-8 flex items-end pb-1">Parameter Key (Regex)</label>
                                 <Input
@@ -5369,7 +5369,7 @@ export default function AdminPage({ onClose }: AdminPageProps) {
                         </div>
                       ))}
 
-                      <div className="flex gap-2 mt-2">
+                      <div className="admin-add-actions flex flex-col sm:flex-row gap-2 mt-2">
                         <Button
                             type="button"
                             variant="outline"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:../vite.config",
     "start": "cross-env NODE_ENV=production node dist/index.js",
-    "test:unit": "tsx tests/shared/appMetadata.test.ts && tsx tests/shared/dependency-security.test.ts && tsx tests/client/url-utils.test.ts && tsx tests/shared/url-trace.test.ts",
+    "test:unit": "tsx tests/shared/appMetadata.test.ts && tsx tests/shared/dependency-security.test.ts && tsx tests/client/url-utils.test.ts && tsx tests/client/admin-responsive.test.ts && tsx tests/shared/url-trace.test.ts",
     "test": "npm run test:unit && tsx tests/integration/test-url-transformation.js && tsx tests/integration/test-rule-specificity.ts && tsx tests/integration/test-server-features.js && tsx tests/integration/test-vite-config.ts && tsx tests/integration/test-public-api.ts",
     "check": "echo 'Skipping type check'"
   },

--- a/tests/client/admin-responsive.test.ts
+++ b/tests/client/admin-responsive.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const readSource = (relativePath: string) =>
+  readFileSync(new URL(`../../${relativePath}`, import.meta.url), "utf8");
+
+const adminPage = readSource("client/src/pages/admin.tsx");
+const dialog = readSource("client/src/components/ui/dialog.tsx");
+const alertDialog = readSource("client/src/components/ui/alert-dialog.tsx");
+const globalRules = readSource("client/src/components/admin/GlobalRulesSettings.tsx");
+
+assert.match(adminPage, /className="admin-shell min-h-screen/);
+assert.match(adminPage, /grid-cols-3[^"]*sm:grid-cols-5/);
+assert.match(adminPage, /admin-rule-actions grid grid-cols-1/);
+assert.match(adminPage, /admin-dialog-actions sticky bottom-0/);
+
+for (const modalSource of [dialog, alertDialog]) {
+  assert.match(modalSource, /w-\[calc\(100%-1rem\)\]/);
+  assert.match(modalSource, /max-h-\[calc\(100dvh-1rem\)\]/);
+  assert.match(modalSource, /\[&_button\]:min-h-11/);
+}
+
+assert.match(globalRules, /admin-editor-row flex flex-col/);
+assert.match(globalRules, /w-full sm:w-auto/);
+
+console.log("Admin responsive layout contract tests passed");

--- a/tests/client/admin-responsive.test.ts
+++ b/tests/client/admin-responsive.test.ts
@@ -8,11 +8,18 @@ const adminPage = readSource("client/src/pages/admin.tsx");
 const dialog = readSource("client/src/components/ui/dialog.tsx");
 const alertDialog = readSource("client/src/components/ui/alert-dialog.tsx");
 const globalRules = readSource("client/src/components/admin/GlobalRulesSettings.tsx");
+const adminStyles = readSource("client/src/index.css");
 
 assert.match(adminPage, /className="admin-shell min-h-screen/);
 assert.match(adminPage, /grid-cols-3[^"]*sm:grid-cols-5/);
 assert.match(adminPage, /admin-rule-actions grid grid-cols-1/);
 assert.match(adminPage, /admin-dialog-actions sticky bottom-0/);
+assert.match(adminPage, /className="admin-rule-form/);
+assert.equal(
+  adminPage.match(/admin-rule-editor-row flex flex-col sm:flex-row/g)?.length,
+  3,
+  "all three repeatable rule editor rows must stack on smartphones",
+);
 
 for (const modalSource of [dialog, alertDialog]) {
   assert.match(modalSource, /w-\[calc\(100%-1rem\)\]/);
@@ -22,5 +29,9 @@ for (const modalSource of [dialog, alertDialog]) {
 
 assert.match(globalRules, /admin-editor-row flex flex-col/);
 assert.match(globalRules, /w-full sm:w-auto/);
+assert.match(adminStyles, /\.admin-shell\s*\{[^}]*overflow-x:\s*clip/s);
+assert.match(adminStyles, /\.admin-rule-form (?:input|textarea),/);
+assert.match(adminStyles, /min-height:\s*44px/);
+assert.match(adminStyles, /\.admin-editor-row > \*/);
 
 console.log("Admin responsive layout contract tests passed");


### PR DESCRIPTION
### Motivation

- Ziel ist, die Admin-Oberfläche auf schmalen Smartphone-Bildschirmen nutzbar zu machen, sodass Buttons (z. B. `Konfigurationsvalidierung`, `Neue Regel`, `Aktualisieren`) nicht abgeschnitten werden und Touch‑Ziele ausreichend groß sind.
- Dialoge und Editoren sollen bei dynamischer Mobile‑Viewport‑Höhe (Browser‑Chrome) korrekt scrollbar bleiben und wichtige Aktionen immer erreichbar sein.
- Formularfelder und Card‑Padding sollen so angepasst werden, dass mobiles Browser‑Zoomen beim Fokussieren reduziert und der Platz besser genutzt wird.

### Description

- Dialog- und Alert-Komponenten wurden zentral verbessert, indem die Dialog‑Shell auf `w-[calc(100%-1rem)]` und `max-h-[calc(100dvh-1rem)]` gesetzt, internes Scrolling (`overflow-y-auto`) aktiviert und Footer‑Buttons touchfreundlich (`[&_button]:min-h-11`) gemacht wurden (`client/src/components/ui/dialog.tsx`, `client/src/components/ui/alert-dialog.tsx`).
- Die Admin‑Seite erhielt eine Wrapper‑Klasse `admin-shell`, die Tab‑Navigation reflowt (`grid-cols-3 sm:grid-cols-5`) und die Rule‑Action‑Leiste responsiv umbricht (`admin-rule-actions`) sowie Dialog‑Footer als sticky, persistente Aktionsleiste (`admin-dialog-actions`) implementiert (`client/src/pages/admin.tsx`).
- Globale Regeln/Editoren stapeln Eingabefelder und machen Aktionsbuttons auf kleinen Bildschirmen vollbreit/lesbar (`client/src/components/admin/GlobalRulesSettings.tsx`).
- Zusätzliche mobile CSS‑Hilfen reduzieren Card‑Padding und erzwingen größere Eingabetext‑Größe (`16px`) zur Vermeidung von Zoom, und die README wurde um Hinweis zu Smartphone‑Optimierungen erweitert (`client/src/index.css`, `README.md`).
- Ein automatisierter Layout‑Contract‑Test wurde hinzugefügt (`tests/client/admin-responsive.test.ts`) und in `package.json` in die Unit‑Tests eingebunden, um die neuen responsiven Klassennamen und Dialog‑Kontrakte zu prüfen.

### Testing

- `npx tsx tests/client/admin-responsive.test.ts` wurde lokal ausgeführt und hat bestanden (prüft Klassen/Contracts in Quelltextdateien).
- `npm run test:unit` (Unit‑Suite inkl. neuem Test) lief erfolgreich ohne Fehler.
- `npm test` inklusive Integrationstests wurde erfolgreich durchlaufen und der Build mit `npm run build` erzeugte ein Produktionsbundle ohne Build‑Fehler.
- `npm audit --audit-level=high` und `npx playwright install chromium` konnten in dieser Umgebung nicht vollständig ausgeführt, da externe Endpunkte mit HTTP 403 blockierten; die vorhandenen lockfile‑Security‑Assertions in der Test‑Suite waren jedoch grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9fbb9420848331a0bbacf215cd1c06)