### PR TITLE
fix(ci): downgrade npm to v11 to avoid EALLOWREMOTE bug

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 22
           cache: 'npm'
       - name: Setup npm
-        run: npm install --global npm@12
+        run: npm install --global npm@11
       - name: Ensure Valid Semver
         run: |
           VER=$(jq -r .version package.json)
@@ -63,7 +63,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup npm
-        run: npm install --global npm@12
+        run: npm install --global npm@11
 
       - name: Ensure Valid Semver
         run: |


### PR DESCRIPTION
npm v12 introduces a bug where `npm install --package-lock-only` fails with an `EALLOWREMOTE` error when trying to resolve optional remote dependencies (like `@tailwindcss/oxide-wasm32-wasi`).

This commit downgrades the npm version used in the GitHub Actions workflow back to v11 to match what is used in the Dockerfiles and restores a working CI build.

---
*PR created automatically by Jules for task [17857828520726660150](https://jules.google.com/task/17857828520726660150) started by @DrunkenHusky*